### PR TITLE
feat(mcp-server): add e2e tests for MCP protocol and calories tools

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,51 @@
+name: E2E Tests
+
+on:
+  # Run automatically after deploy to staging
+  workflow_run:
+    workflows: [Deploy]
+    types: [completed]
+    branches: [staging]
+
+  # Allow manual runs targeting any environment
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: 'MCP server base URL (leave blank to use STG_MCP_SERVER_URL secret)'
+        required: false
+        type: string
+
+jobs:
+  e2e:
+    name: E2E — MCP Server
+    runs-on: ubuntu-latest
+    # For workflow_run trigger: only run when the deploy succeeded
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run E2E tests
+        run: pnpm test:e2e
+        env:
+          # Base URL: prefer the manual input, fall back to the staging secret
+          E2E_BASE_URL: ${{ inputs.base_url || secrets.STG_MCP_SERVER_URL }}
+          # Pre-registered test OAuth client credentials (stored as GitHub secrets)
+          E2E_CLIENT_ID: ${{ secrets.E2E_CLIENT_ID }}
+          E2E_TOKEN_SIGNING_SECRET: ${{ secrets.E2E_TOKEN_SIGNING_SECRET }}
+          E2E_USER_ID: ${{ secrets.E2E_USER_ID }}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "format:check": "pnpm exec prettier --check .",
     "typecheck": "pnpm run build && pnpm --filter @my-hub/shared typecheck && pnpm --filter @my-hub/mcp-server typecheck && pnpm --filter @my-hub/admin typecheck",
     "test": "pnpm -r test",
+    "test:e2e": "pnpm --filter @my-hub/mcp-server test:e2e",
     "db:generate": "pnpm --filter shared db:generate",
     "db:migrate": "pnpm --filter shared db:migrate"
   },

--- a/packages/mcp-server/e2e/README.md
+++ b/packages/mcp-server/e2e/README.md
@@ -1,0 +1,65 @@
+# MCP Server — E2E Tests
+
+Black-box integration tests that run against a live MCP server instance (local or staging).
+
+## How it works
+
+Tests use the MCP Streamable HTTP protocol to call tools and verify responses, without
+inspecting the database directly. The test suite covers:
+
+- **Health endpoint** — status, unknown routes, unauthenticated access
+- **Calories meal lifecycle** — log meal → retrieve → filter → delete → verify gone
+
+## Prerequisites
+
+A pre-registered OAuth client must exist in the target server's database.
+Set these env vars before running:
+
+| Variable                  | Description                                                          |
+| ------------------------- | -------------------------------------------------------------------- |
+| `E2E_CLIENT_ID`           | The `client_id` of the pre-registered test OAuth client              |
+| `E2E_TOKEN_SIGNING_SECRET`| The **raw** (unencrypted) token signing secret for that client       |
+| `E2E_USER_ID`             | UUID of the user the client is authorized for                        |
+| `E2E_BASE_URL`            | Server base URL (default: `http://localhost:3001`)                   |
+
+The test helper generates a fresh signed access token for each run using these credentials,
+so tokens never expire between CI runs.
+
+## Running locally
+
+```bash
+# From repo root — points to localhost:3001 by default
+E2E_CLIENT_ID=hub_xxxxxxxx \
+E2E_TOKEN_SIGNING_SECRET=<raw-secret> \
+E2E_USER_ID=<uuid> \
+pnpm test:e2e
+
+# Or against staging
+E2E_BASE_URL=https://mcp.example.com \
+E2E_CLIENT_ID=hub_xxxxxxxx \
+E2E_TOKEN_SIGNING_SECRET=<raw-secret> \
+E2E_USER_ID=<uuid> \
+pnpm test:e2e
+```
+
+## CI / GitHub Actions
+
+The workflow (`.github/workflows/e2e.yml`) runs automatically after a successful deploy
+to `staging`. It reads credentials from GitHub repository secrets:
+
+- `STG_MCP_SERVER_URL` — staging server URL (set once the domain is known)
+- `E2E_CLIENT_ID`
+- `E2E_TOKEN_SIGNING_SECRET`
+- `E2E_USER_ID`
+
+You can also trigger it manually from the **Actions** tab with a custom base URL.
+
+## Obtaining credentials
+
+1. Register a test OAuth client by completing the OAuth flow once (via the hub UI or
+   a one-off script).
+2. Store the returned `client_id`, the **raw** `tokenSigningSecret` (before DB encryption),
+   and the authorized `userId` as secrets.
+
+> The raw `tokenSigningSecret` is only visible at registration time. If lost, register
+> a new test client.

--- a/packages/mcp-server/e2e/calories.e2e.ts
+++ b/packages/mcp-server/e2e/calories.e2e.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { getE2eEnv } from './helpers/env.js';
+import { generateToken } from './helpers/token.js';
+import { createMcpClient, parseToolResult, type McpClient } from './helpers/mcp-client.js';
+
+interface MealEntry {
+  meal_id: string;
+  date: string;
+  meal_type: string;
+  description: string;
+  calories: number;
+  protein_g: number | null;
+  carbs_g: number | null;
+  fat_g: number | null;
+  notes: string | null;
+  created_at: string;
+}
+
+interface GetMealsResult {
+  entries: MealEntry[];
+  total_count: number;
+  has_more: boolean;
+  next_offset: number | null;
+}
+
+interface LogMealResult {
+  meal_id: string;
+  date: string;
+  meal_type: string;
+  description: string;
+  calories: number;
+  protein_g: number | null;
+  carbs_g: number | null;
+  fat_g: number | null;
+}
+
+interface DeleteMealResult {
+  deleted: boolean;
+  meal_id: string;
+}
+
+/**
+ * E2e tests for the calories MCP sub-server.
+ *
+ * These tests exercise the full meal lifecycle via the MCP protocol:
+ *   log meal → retrieve meals → verify data → delete meal → verify gone
+ *
+ * A unique run ID is embedded in the meal description so test meals can be
+ * identified among real data without relying on a test-only database.
+ */
+describe.sequential('calories — meal lifecycle', () => {
+  let client: McpClient;
+  let mealId: string | undefined;
+
+  // Use a far-future date to avoid colliding with real meal data.
+  // The server only validates YYYY-MM-DD format, not that the date is in the past.
+  const testDate = '2099-01-01';
+  const runId = Date.now().toString(36);
+  const mealDescription = `[e2e:${runId}] Grilled chicken with rice and salad`;
+
+  beforeAll(async () => {
+    const { baseUrl } = getE2eEnv();
+    const token = await generateToken();
+    client = await createMcpClient(baseUrl, '/mcp/calories', token);
+  });
+
+  afterAll(async () => {
+    // Best-effort cleanup: delete the test meal if it was logged but not yet deleted.
+    if (mealId) {
+      try {
+        await client.callTool({ name: 'calories_delete_meal', arguments: { meal_id: mealId } });
+      } catch {
+        // Ignore — meal may already be deleted by a test.
+      }
+    }
+    await client.close();
+  });
+
+  it('logs a meal and returns a meal_id', async () => {
+    const result = await client.callTool({
+      name: 'calories_log_meal',
+      arguments: {
+        description: mealDescription,
+        calories: 550,
+        meal_type: 'lunch',
+        date: testDate,
+        protein_g: 42,
+        carbs_g: 60,
+        fat_g: 12,
+        notes: 'e2e test meal — safe to delete',
+      },
+    });
+
+    const data = parseToolResult<LogMealResult>(result);
+
+    expect(data.meal_id).toBeTruthy();
+    expect(data.date).toBe(testDate);
+    expect(data.meal_type).toBe('lunch');
+    expect(data.description).toBe(mealDescription);
+    expect(data.calories).toBe(550);
+    expect(data.protein_g).toBe(42);
+    expect(data.carbs_g).toBe(60);
+    expect(data.fat_g).toBe(12);
+
+    mealId = data.meal_id;
+  });
+
+  it('retrieves the logged meal with correct data', async () => {
+    expect(mealId).toBeTruthy();
+
+    const result = await client.callTool({
+      name: 'calories_get_meals',
+      arguments: { date: testDate },
+    });
+
+    const data = parseToolResult<GetMealsResult>(result);
+
+    expect(Array.isArray(data.entries)).toBe(true);
+    expect(typeof data.total_count).toBe('number');
+
+    const meal = data.entries.find((e) => e.meal_id === mealId);
+    expect(meal).toBeDefined();
+    expect(meal!.description).toBe(mealDescription);
+    expect(meal!.calories).toBe(550);
+    expect(meal!.meal_type).toBe('lunch');
+    expect(meal!.date).toBe(testDate);
+    expect(meal!.protein_g).toBe(42);
+    expect(meal!.carbs_g).toBe(60);
+    expect(meal!.fat_g).toBe(12);
+    expect(meal!.created_at).toBeTruthy();
+  });
+
+  it('filters meals by meal_type', async () => {
+    const result = await client.callTool({
+      name: 'calories_get_meals',
+      arguments: { date: testDate, meal_type: 'breakfast' },
+    });
+
+    const data = parseToolResult<GetMealsResult>(result);
+    const hasTestMeal = data.entries.some((e) => e.meal_id === mealId);
+    // Our test meal is 'lunch', so it should not appear in breakfast results.
+    expect(hasTestMeal).toBe(false);
+  });
+
+  it('deletes the logged meal', async () => {
+    expect(mealId).toBeTruthy();
+
+    const result = await client.callTool({
+      name: 'calories_delete_meal',
+      arguments: { meal_id: mealId },
+    });
+
+    const data = parseToolResult<DeleteMealResult>(result);
+    expect(data.deleted).toBe(true);
+    expect(data.meal_id).toBe(mealId);
+
+    // Clear so afterAll cleanup skips it.
+    mealId = undefined;
+  });
+
+  it('meal is no longer present after deletion', async () => {
+    const result = await client.callTool({
+      name: 'calories_get_meals',
+      arguments: { date: testDate },
+    });
+
+    const data = parseToolResult<GetMealsResult>(result);
+    // mealId was already cleared above; re-use the run-scoped description to identify
+    const found = data.entries.find((e) => e.description === mealDescription);
+    expect(found).toBeUndefined();
+  });
+
+  it('returns an error when deleting a non-existent meal', async () => {
+    const result = await client.callTool({
+      name: 'calories_delete_meal',
+      arguments: { meal_id: 'non-existent-meal-id-00000000' },
+    });
+
+    // Tools signal errors by setting isError: true on the response.
+    expect(result.isError).toBe(true);
+  });
+});

--- a/packages/mcp-server/e2e/health.e2e.ts
+++ b/packages/mcp-server/e2e/health.e2e.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { getBaseUrl } from './helpers/env.js';
+
+describe('health endpoint', () => {
+  it('returns 200 with status ok', async () => {
+    const baseUrl = getBaseUrl();
+    const res = await fetch(`${baseUrl}/health`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { status: string; timestamp: string };
+    expect(body.status).toBe('ok');
+    expect(body.timestamp).toBeTruthy();
+  });
+
+  it('rejects unknown routes with 404', async () => {
+    const baseUrl = getBaseUrl();
+    const res = await fetch(`${baseUrl}/this-does-not-exist`);
+    expect(res.status).toBe(404);
+  });
+
+  it('rejects mcp endpoint without auth with 401', async () => {
+    const baseUrl = getBaseUrl();
+    const res = await fetch(`${baseUrl}/mcp/calories`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize' }),
+    });
+    expect(res.status).toBe(401);
+  });
+});

--- a/packages/mcp-server/e2e/helpers/env.ts
+++ b/packages/mcp-server/e2e/helpers/env.ts
@@ -1,0 +1,39 @@
+/**
+ * E2e environment configuration.
+ *
+ * Required env vars:
+ *   E2E_CLIENT_ID            - Pre-registered OAuth client ID (e.g. hub_xxxxxxxx)
+ *   E2E_TOKEN_SIGNING_SECRET - Raw (unencrypted) token signing secret for that client
+ *   E2E_USER_ID              - UUID of the user this client is authorized for
+ *
+ * Optional env vars:
+ *   E2E_BASE_URL             - Server base URL (default: http://localhost:3001)
+ */
+export interface E2eEnv {
+  baseUrl: string;
+  clientId: string;
+  tokenSigningSecret: string;
+  userId: string;
+}
+
+/** Base URL only — usable without auth credentials (defaults to localhost). */
+export function getBaseUrl(): string {
+  return process.env['E2E_BASE_URL'] ?? 'http://localhost:3001';
+}
+
+/** Full env with auth credentials — required for authenticated MCP requests. */
+export function getE2eEnv(): E2eEnv {
+  const baseUrl = getBaseUrl();
+  const clientId = process.env['E2E_CLIENT_ID'];
+  const tokenSigningSecret = process.env['E2E_TOKEN_SIGNING_SECRET'];
+  const userId = process.env['E2E_USER_ID'];
+
+  if (!clientId || !tokenSigningSecret || !userId) {
+    throw new Error(
+      'Missing required e2e env vars: E2E_CLIENT_ID, E2E_TOKEN_SIGNING_SECRET, E2E_USER_ID\n' +
+        'See packages/mcp-server/e2e/README.md for setup instructions.',
+    );
+  }
+
+  return { baseUrl, clientId, tokenSigningSecret, userId };
+}

--- a/packages/mcp-server/e2e/helpers/mcp-client.ts
+++ b/packages/mcp-server/e2e/helpers/mcp-client.ts
@@ -1,0 +1,32 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+
+export type McpClient = Client;
+
+/**
+ * Creates and connects an MCP client to the given endpoint.
+ * The Bearer token is attached to every request via requestInit headers.
+ */
+export async function createMcpClient(baseUrl: string, path: string, token: string): Promise<McpClient> {
+  const url = new URL(path, baseUrl);
+  const transport = new StreamableHTTPClientTransport(url, {
+    requestInit: {
+      headers: { Authorization: `Bearer ${token}` },
+    },
+  });
+  const client = new Client({ name: 'e2e-test-client', version: '1.0.0' });
+  await client.connect(transport);
+  return client;
+}
+
+/**
+ * Parses the JSON text from the first content item of an MCP tool result.
+ * All tools in this project return `{ content: [{ type: 'text', text: JSON }] }`.
+ */
+export function parseToolResult<T = unknown>(result: Awaited<ReturnType<Client['callTool']>>): T {
+  const item = result.content[0];
+  if (!item || item.type !== 'text') {
+    throw new Error(`Unexpected MCP content type: ${item?.type ?? 'none'}`);
+  }
+  return JSON.parse(item.text) as T;
+}

--- a/packages/mcp-server/e2e/helpers/token.ts
+++ b/packages/mcp-server/e2e/helpers/token.ts
@@ -1,0 +1,19 @@
+import { signToken } from '@my-hub/shared/auth';
+import { getE2eEnv } from './env.js';
+
+/**
+ * Generates a fresh access token signed with the test client's tokenSigningSecret.
+ * The token is valid for 1 hour from the time of generation.
+ *
+ * This mirrors the token produced by POST /token in the OAuth flow, and is
+ * accepted by hubTokenVerifier as long as the OAuth client exists in the DB.
+ */
+export async function generateToken(): Promise<string> {
+  const { clientId, tokenSigningSecret, userId } = getE2eEnv();
+  const payload = {
+    client_id: clientId,
+    user_id: userId,
+    exp: Date.now() + 60 * 60 * 1_000, // 1 hour
+  };
+  return signToken(payload, tokenSigningSecret);
+}

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -11,7 +11,8 @@
     "start": "node dist/main.js",
     "lint": "pnpm exec eslint src",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:e2e": "vitest run --config vitest.e2e.config.ts"
   },
   "dependencies": {
     "@fastify/cors": "^9.0.1",

--- a/packages/mcp-server/vitest.e2e.config.ts
+++ b/packages/mcp-server/vitest.e2e.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['e2e/**/*.e2e.ts'],
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
+    // E2e tests are stateful — run files and tests sequentially
+    pool: 'forks',
+    poolOptions: { forks: { singleFork: true } },
+    sequence: { concurrent: false },
+  },
+});


### PR DESCRIPTION
Black-box e2e tests that run against a live server (local or staging)
using the MCP Streamable HTTP protocol. No database inspection.

Test coverage:
- Health endpoint: status, 404 on unknown routes, 401 without auth
- Calories meal lifecycle: log → retrieve → filter by type → delete → verify gone
- Error handling: deleting a non-existent meal

Setup:
- `packages/mcp-server/e2e/` — test files and helpers
- `vitest.e2e.config.ts` — separate Vitest config, runs tests sequentially
- Token helper generates fresh signed tokens from env vars (no expiry issues in CI)
- GitHub Actions workflow (`e2e.yml`) triggers after staging deploy or manually

Run locally: `pnpm test:e2e` with E2E_CLIENT_ID / E2E_TOKEN_SIGNING_SECRET / E2E_USER_ID

https://claude.ai/code/session_01PXzFCBGfEZLeSdWm1wjY9v