### PR TITLE
feat: Add todo MCP server, hub page, and e2e tests

### DIFF
--- a/packages/e2e/tests/helpers.ts
+++ b/packages/e2e/tests/helpers.ts
@@ -8,7 +8,7 @@ export async function deleteAllData(page: Page): Promise<void> {
 /** Wipe only specific data features. */
 export async function deleteFeatures(
   page: Page,
-  features: ('meals' | 'measurements' | 'calories_profile')[],
+  features: ('meals' | 'measurements' | 'calories_profile' | 'todos')[],
 ): Promise<void> {
   await page.request.post('/api/user/delete-data', { data: { features } });
 }

--- a/packages/e2e/tests/todo.spec.ts
+++ b/packages/e2e/tests/todo.spec.ts
@@ -1,0 +1,94 @@
+import { test, expect } from '@playwright/test';
+import { deleteFeatures } from './helpers';
+
+test.describe('Todo', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/todo');
+    await page.waitForLoadState('networkidle');
+    await deleteFeatures(page, ['todos']);
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+  });
+
+  test('page shows Todo heading and Add item section', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: 'Todo', level: 1 })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Add item', level: 2 })).toBeVisible();
+  });
+
+  test('empty state shows All done message', async ({ page }) => {
+    await expect(page.getByText('All done!')).toBeVisible();
+  });
+
+  test('adds a todo item', async ({ page }) => {
+    await page.getByRole('textbox', { name: /title/i }).fill('Buy groceries');
+    await page.getByRole('button', { name: /^add$/i }).click();
+
+    await expect(page.getByText('Buy groceries')).toBeVisible({ timeout: 5_000 });
+  });
+
+  test('added item appears in the Open section', async ({ page }) => {
+    await page.getByRole('textbox', { name: /title/i }).fill('Write tests');
+    await page.getByRole('button', { name: /^add$/i }).click();
+
+    await expect(page.getByRole('heading', { name: /^Open \(1\)$/i })).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByText('Write tests')).toBeVisible();
+  });
+
+  test('submits todo with Enter key', async ({ page }) => {
+    await page.getByRole('textbox', { name: /title/i }).fill('Press enter todo');
+    await page.getByRole('textbox', { name: /title/i }).press('Enter');
+
+    await expect(page.getByText('Press enter todo')).toBeVisible({ timeout: 5_000 });
+  });
+
+  test('marks a todo as done', async ({ page }) => {
+    // Add a todo first
+    await page.getByRole('textbox', { name: /title/i }).fill('Finish this task');
+    await page.getByRole('button', { name: /^add$/i }).click();
+    await expect(page.getByText('Finish this task')).toBeVisible({ timeout: 5_000 });
+
+    // Mark it done
+    await page
+      .getByRole('button', { name: /mark done/i })
+      .first()
+      .click();
+
+    // Should move out of Open and into Done
+    await expect(page.getByRole('heading', { name: /^Done \(1\)$/i })).toBeVisible({ timeout: 5_000 });
+    // The item should now be struck through (in Done section)
+    const doneSection = page.getByRole('heading', { name: /^Done/i }).locator('..').locator('..');
+    await expect(doneSection.getByText('Finish this task')).toBeVisible();
+  });
+
+  test('done item no longer appears in Open section', async ({ page }) => {
+    await page.getByRole('textbox', { name: /title/i }).fill('Complete me');
+    await page.getByRole('button', { name: /^add$/i }).click();
+    await expect(page.getByRole('heading', { name: /^Open \(1\)/i })).toBeVisible({ timeout: 5_000 });
+
+    await page
+      .getByRole('button', { name: /mark done/i })
+      .first()
+      .click();
+
+    // Open count should go back to 0 — "All done!" shows up
+    await expect(page.getByText('All done!')).toBeVisible({ timeout: 5_000 });
+  });
+
+  test('multiple todos are listed in order', async ({ page }) => {
+    await page.getByRole('textbox', { name: /title/i }).fill('First item');
+    await page.getByRole('button', { name: /^add$/i }).click();
+    await expect(page.getByText('First item')).toBeVisible({ timeout: 5_000 });
+
+    await page.getByRole('textbox', { name: /title/i }).fill('Second item');
+    await page.getByRole('button', { name: /^add$/i }).click();
+    await expect(page.getByText('Second item')).toBeVisible({ timeout: 5_000 });
+
+    await expect(page.getByRole('heading', { name: /^Open \(2\)/i })).toBeVisible();
+  });
+
+  test('home page has a Todo tile', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+    await expect(page.getByRole('link', { name: /todo/i })).toBeVisible();
+  });
+});

--- a/packages/hub/src/app/api/todo/[id]/route.ts
+++ b/packages/hub/src/app/api/todo/[id]/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from 'next/server';
+import { getAuthUser } from '@/lib/auth-user';
+import { markTodoDone } from '@my-hub/shared/services';
+
+export async function PATCH(_req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const user = await getAuthUser();
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const { id } = await params;
+  const numId = Number(id);
+  if (!Number.isInteger(numId) || numId <= 0) {
+    return NextResponse.json({ error: 'Invalid id' }, { status: 400 });
+  }
+
+  const todo = await markTodoDone(user.id, numId);
+  if (!todo) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+  return NextResponse.json({ todo });
+}

--- a/packages/hub/src/app/api/todo/route.ts
+++ b/packages/hub/src/app/api/todo/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from 'next/server';
+import { getAuthUser } from '@/lib/auth-user';
+import { getTodos, addTodo } from '@my-hub/shared/services';
+
+export async function GET() {
+  const user = await getAuthUser();
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const items = await getTodos(user.id);
+  return NextResponse.json({ todos: items });
+}
+
+export async function POST(req: Request) {
+  const user = await getAuthUser();
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  let body: Record<string, unknown>;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const { title } = body as { title?: string };
+  if (!title?.trim()) {
+    return NextResponse.json({ error: 'title is required' }, { status: 400 });
+  }
+
+  const todo = await addTodo(user.id, title.trim());
+  return NextResponse.json({ todo }, { status: 201 });
+}

--- a/packages/hub/src/app/api/user/delete-data/route.ts
+++ b/packages/hub/src/app/api/user/delete-data/route.ts
@@ -1,10 +1,15 @@
 import { NextResponse } from 'next/server';
 import { getAuthUser } from '@/lib/auth-user';
-import { deleteAllUserMeals, deleteAllUserMeasurements, deleteCalorieProfile } from '@my-hub/shared/services';
+import {
+  deleteAllUserMeals,
+  deleteAllUserMeasurements,
+  deleteCalorieProfile,
+  deleteAllUserTodos,
+} from '@my-hub/shared/services';
 
-type Feature = 'meals' | 'measurements' | 'calories_profile';
+type Feature = 'meals' | 'measurements' | 'calories_profile' | 'todos';
 
-const SUPPORTED_FEATURES: Feature[] = ['meals', 'measurements', 'calories_profile'];
+const SUPPORTED_FEATURES: Feature[] = ['meals', 'measurements', 'calories_profile', 'todos'];
 
 export async function POST(req: Request) {
   const user = await getAuthUser();
@@ -47,6 +52,11 @@ export async function POST(req: Request) {
       case 'calories_profile': {
         const deleted = await deleteCalorieProfile(user.id);
         results.calories_profile = { deleted };
+        break;
+      }
+      case 'todos': {
+        const count = await deleteAllUserTodos(user.id);
+        results.todos = { deleted: count };
         break;
       }
     }

--- a/packages/hub/src/app/page.tsx
+++ b/packages/hub/src/app/page.tsx
@@ -20,6 +20,13 @@ const appSections = [
     color: 'bg-orange-50 border-orange-200 hover:border-orange-400',
     labelColor: 'text-orange-700',
   },
+  {
+    href: '/todo',
+    label: 'Todo',
+    description: 'Simple todo list for testing MCP integration',
+    color: 'bg-blue-50 border-blue-200 hover:border-blue-400',
+    labelColor: 'text-blue-700',
+  },
 ];
 
 const adminSections = [

--- a/packages/hub/src/app/todo/page.tsx
+++ b/packages/hub/src/app/todo/page.tsx
@@ -1,0 +1,177 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import Link from 'next/link';
+import type { Todo } from '@my-hub/shared/types';
+import PageHeader from '@/components/page-header';
+import SectionCard from '@/components/section-card';
+import Button from '@/components/button';
+import Field from '@/components/field';
+
+export default function TodoPage() {
+  const [todos, setTodos] = useState<Todo[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [title, setTitle] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [marking, setMarking] = useState<number | null>(null);
+
+  const loadTodos = useCallback(async () => {
+    try {
+      const res = await fetch('/api/todo');
+      if (res.status === 401) {
+        setError('Not signed in');
+        return;
+      }
+      const data = (await res.json()) as { todos: Todo[] };
+      setTodos(data.todos);
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadTodos();
+  }, [loadTodos]);
+
+  async function addTodo() {
+    if (!title.trim()) return;
+    setSaving(true);
+    try {
+      await fetch('/api/todo', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title: title.trim() }),
+      });
+      setTitle('');
+      await loadTodos();
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function markDone(id: number) {
+    setMarking(id);
+    try {
+      await fetch(`/api/todo/${id}`, { method: 'PATCH' });
+      await loadTodos();
+    } finally {
+      setMarking(null);
+    }
+  }
+
+  if (loading) {
+    return (
+      <main className="mx-auto max-w-3xl p-8">
+        <div className="text-gray-400">Loading…</div>
+      </main>
+    );
+  }
+
+  if (error) {
+    return (
+      <main className="mx-auto max-w-3xl p-8">
+        <p className="text-red-500">{error}</p>
+        {error === 'Not signed in' && (
+          <Link href="/auth/signin" className="mt-2 inline-block text-blue-600 underline">
+            Sign in
+          </Link>
+        )}
+      </main>
+    );
+  }
+
+  const open = todos.filter((t) => !t.done);
+  const done = todos.filter((t) => t.done);
+
+  return (
+    <main className="mx-auto max-w-3xl p-8 space-y-6">
+      <PageHeader title="Todo" backHref="/" backLabel="← Home" />
+
+      {/* Add form */}
+      <SectionCard title="Add item">
+        <div className="flex gap-3 items-end">
+          <Field label="Title" className="flex-1">
+            <input
+              className="input"
+              placeholder="What needs to be done?"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              onKeyDown={(e) => e.key === 'Enter' && addTodo()}
+              autoFocus
+            />
+          </Field>
+          <Button onClick={addTodo} loading={saving} disabled={!title.trim()}>
+            Add
+          </Button>
+        </div>
+      </SectionCard>
+
+      {/* Open todos */}
+      <SectionCard title={`Open (${open.length})`}>
+        {open.length === 0 ? (
+          <p className="text-gray-400 text-sm">All done!</p>
+        ) : (
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-left text-xs font-semibold uppercase tracking-wide text-gray-400 border-b border-gray-100">
+                <th className="pb-2 pr-4">ID</th>
+                <th className="pb-2 flex-1">Title</th>
+                <th className="pb-2 pl-4 text-right">Created</th>
+                <th className="pb-2 pl-4"></th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-50">
+              {open.map((todo) => (
+                <tr key={todo.id} className="hover:bg-gray-50">
+                  <td className="py-2 pr-4 text-gray-400 font-mono text-xs">{todo.id}</td>
+                  <td className="py-2 font-medium">{todo.title}</td>
+                  <td className="py-2 pl-4 text-right text-gray-400 text-xs whitespace-nowrap">
+                    {new Date(todo.createdAt).toLocaleDateString()}
+                  </td>
+                  <td className="py-2 pl-4 text-right">
+                    <button
+                      onClick={() => markDone(todo.id)}
+                      disabled={marking === todo.id}
+                      className="text-xs text-blue-600 hover:text-blue-800 disabled:opacity-50"
+                    >
+                      {marking === todo.id ? '…' : 'Mark done'}
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </SectionCard>
+
+      {/* Done todos */}
+      {done.length > 0 && (
+        <SectionCard title={`Done (${done.length})`}>
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-left text-xs font-semibold uppercase tracking-wide text-gray-400 border-b border-gray-100">
+                <th className="pb-2 pr-4">ID</th>
+                <th className="pb-2 flex-1">Title</th>
+                <th className="pb-2 pl-4 text-right">Created</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-50">
+              {done.map((todo) => (
+                <tr key={todo.id} className="opacity-50">
+                  <td className="py-2 pr-4 text-gray-400 font-mono text-xs">{todo.id}</td>
+                  <td className="py-2 line-through text-gray-500">{todo.title}</td>
+                  <td className="py-2 pl-4 text-right text-gray-400 text-xs whitespace-nowrap">
+                    {new Date(todo.createdAt).toLocaleDateString()}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </SectionCard>
+      )}
+    </main>
+  );
+}

--- a/packages/mcp-server/e2e/todo.e2e.ts
+++ b/packages/mcp-server/e2e/todo.e2e.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { getE2eEnv } from './helpers/env.js';
+import { generateToken } from './helpers/token.js';
+import { createMcpClient, parseToolResult, type McpClient } from './helpers/mcp-client.js';
+
+interface TodoItem {
+  id: number;
+  userId: string;
+  title: string;
+  done: boolean;
+  createdAt: string;
+}
+
+/**
+ * E2E tests for the todo MCP sub-server.
+ *
+ * Exercises the full lifecycle via the MCP protocol:
+ *   add → list → mark done → verify done → resource shows only open items
+ *
+ * A unique run ID is embedded in the title so test items can be identified
+ * among real data without relying on a test-only database.
+ */
+describe.sequential('todo — lifecycle', () => {
+  let client: McpClient;
+  let todoId: number | undefined;
+
+  const runId = Date.now().toString(36);
+  const todoTitle = `[e2e:${runId}] Buy milk`;
+
+  beforeAll(async () => {
+    const { baseUrl } = getE2eEnv();
+    const token = await generateToken();
+    client = await createMcpClient(baseUrl, '/mcp/todo', token);
+  });
+
+  afterAll(async () => {
+    await client.close();
+  });
+
+  it('adds a todo item and returns it', async () => {
+    const result = await client.callTool({
+      name: 'todo_add',
+      arguments: { title: todoTitle },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const data = parseToolResult<TodoItem>(result);
+
+    expect(data.id).toBeGreaterThan(0);
+    expect(data.title).toBe(todoTitle);
+    expect(data.done).toBe(false);
+    expect(data.createdAt).toBeTruthy();
+
+    todoId = data.id;
+  });
+
+  it('todo_list returns the added item', async () => {
+    expect(todoId).toBeDefined();
+
+    const result = await client.callTool({ name: 'todo_list', arguments: {} });
+
+    expect(result.isError).toBeFalsy();
+    const items = parseToolResult<TodoItem[]>(result);
+
+    expect(Array.isArray(items)).toBe(true);
+    const found = items.find((t) => t.id === todoId);
+    expect(found).toBeDefined();
+    expect(found!.title).toBe(todoTitle);
+    expect(found!.done).toBe(false);
+  });
+
+  it('todo://open resource includes the open item', async () => {
+    expect(todoId).toBeDefined();
+
+    const result = await client.readResource({ uri: 'todo://open' });
+
+    const raw = result.contents[0];
+    expect(raw).toBeDefined();
+    const data = JSON.parse(raw!.text as string) as { open_todos: TodoItem[]; count: number };
+
+    expect(typeof data.count).toBe('number');
+    expect(Array.isArray(data.open_todos)).toBe(true);
+    const found = data.open_todos.find((t) => t.id === todoId);
+    expect(found).toBeDefined();
+    expect(found!.done).toBe(false);
+  });
+
+  it('marks the todo as done', async () => {
+    expect(todoId).toBeDefined();
+
+    const result = await client.callTool({
+      name: 'todo_mark_done',
+      arguments: { id: todoId },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const data = parseToolResult<TodoItem>(result);
+
+    expect(data.id).toBe(todoId);
+    expect(data.done).toBe(true);
+  });
+
+  it('todo_list shows item as done', async () => {
+    expect(todoId).toBeDefined();
+
+    const result = await client.callTool({ name: 'todo_list', arguments: {} });
+
+    const items = parseToolResult<TodoItem[]>(result);
+    const found = items.find((t) => t.id === todoId);
+    expect(found).toBeDefined();
+    expect(found!.done).toBe(true);
+  });
+
+  it('todo://open resource no longer includes the done item', async () => {
+    expect(todoId).toBeDefined();
+
+    const result = await client.readResource({ uri: 'todo://open' });
+
+    const raw = result.contents[0];
+    const data = JSON.parse(raw!.text as string) as { open_todos: TodoItem[]; count: number };
+
+    const found = data.open_todos.find((t) => t.id === todoId);
+    expect(found).toBeUndefined();
+  });
+
+  it('returns an error when marking a non-existent id as done', async () => {
+    const result = await client.callTool({
+      name: 'todo_mark_done',
+      arguments: { id: 999_999_999 },
+    });
+
+    expect(result.isError).toBe(true);
+  });
+});

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -8,6 +8,7 @@ import { sessionCleanupPlugin } from './plugins/session-cleanup.js';
 import { registerMcpSubServer } from './mcp/sub-server.js';
 import { mcpSubServers } from './mcp/registry.js';
 import { createCaloriesServer } from './calories/server.js';
+import { createTodoServer } from './todo/server.js';
 import { envConfig } from './config/env.js';
 
 export async function buildServer() {
@@ -34,6 +35,7 @@ export async function buildServer() {
   // MCP sub-servers — each domain gets its own endpoint and session manager.
   // Add more sub-servers here as new domains are implemented.
   registerMcpSubServer(app, '/mcp/calories', createCaloriesServer);
+  registerMcpSubServer(app, '/mcp/todo', createTodoServer);
   // registerMcpSubServer(app, '/mcp/hive-manager', createHiveManagerServer);
 
   // Session cleanup plugin (reads mcpSubServers registry via onReady hook)

--- a/packages/mcp-server/src/todo/resources.ts
+++ b/packages/mcp-server/src/todo/resources.ts
@@ -1,0 +1,35 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { getOpenTodos } from '@my-hub/shared/services';
+
+function resourceResponse(payload: unknown) {
+  return {
+    contents: [
+      {
+        uri: '',
+        mimeType: 'application/json',
+        text: JSON.stringify(payload, null, 2),
+      },
+    ],
+  };
+}
+
+export function registerTodoResources(server: McpServer): void {
+  /**
+   * todo://open
+   * All unfinished todo items for the authenticated user.
+   */
+  server.registerResource(
+    'todo-open',
+    'todo://open',
+    {
+      description: 'All unfinished (open) todo items for the current user.',
+      mimeType: 'application/json',
+    },
+    async (_uri, extra) => {
+      const userId = extra.authInfo?.extra?.['userId'] as string | undefined;
+      if (!userId) throw new Error('Authentication required');
+      const items = await getOpenTodos(userId);
+      return resourceResponse({ open_todos: items, count: items.length });
+    },
+  );
+}

--- a/packages/mcp-server/src/todo/server.ts
+++ b/packages/mcp-server/src/todo/server.ts
@@ -1,0 +1,15 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { registerTodoTools } from './tools/todos';
+import { registerTodoResources } from './resources';
+
+export function createTodoServer(): McpServer {
+  const server = new McpServer({
+    name: 'todo-mcp-server',
+    version: '1.0.0',
+  });
+
+  registerTodoTools(server);
+  registerTodoResources(server);
+
+  return server;
+}

--- a/packages/mcp-server/src/todo/tools/todos.ts
+++ b/packages/mcp-server/src/todo/tools/todos.ts
@@ -1,0 +1,65 @@
+import { z } from 'zod';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { addTodo, markTodoDone, getTodos } from '@my-hub/shared/services';
+
+const AddTodoSchema = z.object({
+  title: z.string().min(1).describe('The todo item text'),
+});
+
+const MarkDoneSchema = z.object({
+  id: z.number().int().positive().describe('The id of the todo item to mark as done'),
+});
+
+function toolResponse(payload: unknown) {
+  return {
+    content: [{ type: 'text' as const, text: JSON.stringify(payload) }],
+  };
+}
+
+export function registerTodoTools(server: McpServer) {
+  server.registerTool(
+    'todo_add',
+    {
+      description: 'Add a new todo item',
+      inputSchema: AddTodoSchema.shape,
+      annotations: { idempotentHint: false, destructiveHint: false },
+    },
+    async (input: z.infer<typeof AddTodoSchema>, extra) => {
+      const userId = extra.authInfo?.extra?.['userId'] as string | undefined;
+      if (!userId) throw new Error('Authentication required');
+      const todo = await addTodo(userId, input.title);
+      return toolResponse(todo);
+    },
+  );
+
+  server.registerTool(
+    'todo_mark_done',
+    {
+      description: 'Mark a todo item as done by its id',
+      inputSchema: MarkDoneSchema.shape,
+      annotations: { idempotentHint: true, destructiveHint: false },
+    },
+    async (input: z.infer<typeof MarkDoneSchema>, extra) => {
+      const userId = extra.authInfo?.extra?.['userId'] as string | undefined;
+      if (!userId) throw new Error('Authentication required');
+      const todo = await markTodoDone(userId, input.id);
+      if (!todo) throw new Error(`Todo with id ${input.id} not found`);
+      return toolResponse(todo);
+    },
+  );
+
+  server.registerTool(
+    'todo_list',
+    {
+      description: 'List all todo items (both open and done)',
+      inputSchema: {},
+      annotations: { readOnlyHint: true },
+    },
+    async (_input, extra) => {
+      const userId = extra.authInfo?.extra?.['userId'] as string | undefined;
+      if (!userId) throw new Error('Authentication required');
+      const items = await getTodos(userId);
+      return toolResponse(items);
+    },
+  );
+}

--- a/packages/shared/drizzle/0004_wonderful_malcolm_colcord.sql
+++ b/packages/shared/drizzle/0004_wonderful_malcolm_colcord.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS "todos" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"user_id" uuid NOT NULL,
+	"title" text NOT NULL,
+	"done" boolean DEFAULT false NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "todos" ADD CONSTRAINT "todos_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;

--- a/packages/shared/drizzle/meta/0004_snapshot.json
+++ b/packages/shared/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,1015 @@
+{
+  "id": "0f057d12-9c42-4727-a4cd-2228ee6c210f",
+  "prevId": "613f3b97-9ea3-4c66-8de9-4bd3e620e8ca",
+  "version": "6",
+  "dialect": "postgresql",
+  "tables": {
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "google_id": {
+          "name": "google_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      }
+    },
+    "public.oauth_clients": {
+      "name": "oauth_clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_signing_secret": {
+          "name": "token_signing_secret",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_clients_user_id_users_id_fk": {
+          "name": "oauth_clients_user_id_users_id_fk",
+          "tableFrom": "oauth_clients",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_clients_client_id_unique": {
+          "name": "oauth_clients_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_id"
+          ]
+        }
+      }
+    },
+    "public.mcp_servers": {
+      "name": "mcp_servers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "server_name": {
+          "name": "server_name",
+          "type": "mcp_server",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mcp_servers_user_id_users_id_fk": {
+          "name": "mcp_servers_user_id_users_id_fk",
+          "tableFrom": "mcp_servers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_mcp_user_server": {
+          "name": "uq_mcp_user_server",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "server_name"
+          ]
+        }
+      }
+    },
+    "public.hive_logs": {
+      "name": "hive_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "hive_id": {
+          "name": "hive_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logged_at": {
+          "name": "logged_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "hive_logs_hive_id_hives_id_fk": {
+          "name": "hive_logs_hive_id_hives_id_fk",
+          "tableFrom": "hive_logs",
+          "tableTo": "hives",
+          "columnsFrom": [
+            "hive_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.hive_todos": {
+      "name": "hive_todos",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "hive_id": {
+          "name": "hive_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed": {
+          "name": "completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "hive_todos_hive_id_hives_id_fk": {
+          "name": "hive_todos_hive_id_hives_id_fk",
+          "tableFrom": "hive_todos",
+          "tableTo": "hives",
+          "columnsFrom": [
+            "hive_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.hives": {
+      "name": "hives",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.calorie_profiles": {
+      "name": "calorie_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "age": {
+          "name": "age",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sex": {
+          "name": "sex",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height_cm": {
+          "name": "height_cm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activity_level": {
+          "name": "activity_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goal_type": {
+          "name": "goal_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goal_weekly_rate_kg": {
+          "name": "goal_weekly_rate_kg",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goal_min_calories": {
+          "name": "goal_min_calories",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goal_max_calories": {
+          "name": "goal_max_calories",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "calorie_profiles_user_id_users_id_fk": {
+          "name": "calorie_profiles_user_id_users_id_fk",
+          "tableFrom": "calorie_profiles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "calorie_profiles_user_id_unique": {
+          "name": "calorie_profiles_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      }
+    },
+    "public.meal_logs": {
+      "name": "meal_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "meal_id": {
+          "name": "meal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logged_at": {
+          "name": "logged_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "meal_type": {
+          "name": "meal_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kcal": {
+          "name": "kcal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "protein": {
+          "name": "protein",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "carbs": {
+          "name": "carbs",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fat": {
+          "name": "fat",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_meal_logs_user": {
+          "name": "idx_meal_logs_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_meal_logs_date": {
+          "name": "idx_meal_logs_date",
+          "columns": [
+            "date"
+          ],
+          "isUnique": false
+        },
+        "idx_meal_logs_user_date": {
+          "name": "idx_meal_logs_user_date",
+          "columns": [
+            "user_id",
+            "date"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meal_logs_user_id_users_id_fk": {
+          "name": "meal_logs_user_id_users_id_fk",
+          "tableFrom": "meal_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "meal_logs_meal_id_unique": {
+          "name": "meal_logs_meal_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "meal_id"
+          ]
+        }
+      }
+    },
+    "public.body_measurements": {
+      "name": "body_measurements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_key": {
+          "name": "type_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_body_measurements_user": {
+          "name": "idx_body_measurements_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_body_measurements_date": {
+          "name": "idx_body_measurements_date",
+          "columns": [
+            "date"
+          ],
+          "isUnique": false
+        },
+        "idx_body_measurements_user_date": {
+          "name": "idx_body_measurements_user_date",
+          "columns": [
+            "user_id",
+            "date"
+          ],
+          "isUnique": false
+        },
+        "idx_body_measurements_user_type": {
+          "name": "idx_body_measurements_user_type",
+          "columns": [
+            "user_id",
+            "type_key"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "body_measurements_user_id_users_id_fk": {
+          "name": "body_measurements_user_id_users_id_fk",
+          "tableFrom": "body_measurements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "body_measurements_type_key_measurement_types_key_fk": {
+          "name": "body_measurements_type_key_measurement_types_key_fk",
+          "tableFrom": "body_measurements",
+          "tableTo": "measurement_types",
+          "columnsFrom": [
+            "type_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.measurement_types": {
+      "name": "measurement_types",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.api_request_logs": {
+      "name": "api_request_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "service": {
+          "name": "service",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "inet",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_body": {
+          "name": "request_body",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_body": {
+          "name": "response_body",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_logs_created_at": {
+          "name": "idx_logs_created_at",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_logs_path": {
+          "name": "idx_logs_path",
+          "columns": [
+            "path"
+          ],
+          "isUnique": false
+        },
+        "idx_logs_user": {
+          "name": "idx_logs_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_logs_status": {
+          "name": "idx_logs_status",
+          "columns": [
+            "status_code"
+          ],
+          "isUnique": false
+        },
+        "idx_logs_service": {
+          "name": "idx_logs_service",
+          "columns": [
+            "service"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.todos": {
+      "name": "todos",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "done": {
+          "name": "done",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "todos_user_id_users_id_fk": {
+          "name": "todos_user_id_users_id_fk",
+          "tableFrom": "todos",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {
+    "public.mcp_server": {
+      "name": "mcp_server",
+      "schema": "public",
+      "values": [
+        "calories",
+        "hive",
+        "products"
+      ]
+    }
+  },
+  "schemas": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/shared/drizzle/meta/_journal.json
+++ b/packages/shared/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1773612176837,
       "tag": "0003_seed-calories-measurement-types",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "6",
+      "when": 1773654697935,
+      "tag": "0004_wonderful_malcolm_colcord",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/shared/src/db/schema/index.ts
+++ b/packages/shared/src/db/schema/index.ts
@@ -5,3 +5,4 @@ export * from './hive';
 export * from './calories';
 export * from './measurements';
 export * from './api-request-logs';
+export * from './todos';

--- a/packages/shared/src/db/schema/todos.ts
+++ b/packages/shared/src/db/schema/todos.ts
@@ -1,0 +1,12 @@
+import { pgTable, serial, text, boolean, timestamp, uuid } from 'drizzle-orm/pg-core';
+import { users } from './users';
+
+export const todos = pgTable('todos', {
+  id: serial('id').primaryKey(),
+  userId: uuid('user_id')
+    .notNull()
+    .references(() => users.id),
+  title: text('title').notNull(),
+  done: boolean('done').notNull().default(false),
+  createdAt: timestamp('created_at').notNull().defaultNow(),
+});

--- a/packages/shared/src/services/index.ts
+++ b/packages/shared/src/services/index.ts
@@ -4,3 +4,4 @@ export * from './oauth-clients/index';
 export * from './mcp-servers/index';
 export * from './measurements/index';
 export * from './logs/index';
+export * from './todos/index';

--- a/packages/shared/src/services/todos/index.ts
+++ b/packages/shared/src/services/todos/index.ts
@@ -1,0 +1,36 @@
+import { and, eq } from 'drizzle-orm';
+import { db } from '../../db/client';
+import { todos } from '../../db/schema/todos';
+import type { Todo } from '../../types/index';
+
+export async function getTodos(userId: string): Promise<Todo[]> {
+  return db.select().from(todos).where(eq(todos.userId, userId)).orderBy(todos.createdAt);
+}
+
+export async function getOpenTodos(userId: string): Promise<Todo[]> {
+  return db
+    .select()
+    .from(todos)
+    .where(and(eq(todos.userId, userId), eq(todos.done, false)))
+    .orderBy(todos.createdAt);
+}
+
+export async function addTodo(userId: string, title: string): Promise<Todo> {
+  const [row] = await db.insert(todos).values({ userId, title }).returning();
+  if (!row) throw new Error('Insert did not return a row');
+  return row;
+}
+
+export async function markTodoDone(userId: string, id: number): Promise<Todo | null> {
+  const [row] = await db
+    .update(todos)
+    .set({ done: true })
+    .where(and(eq(todos.userId, userId), eq(todos.id, id)))
+    .returning();
+  return row ?? null;
+}
+
+export async function deleteAllUserTodos(userId: string): Promise<number> {
+  const rows = await db.delete(todos).where(eq(todos.userId, userId)).returning({ id: todos.id });
+  return rows.length;
+}

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -12,6 +12,7 @@ import type {
   measurementTypes,
   bodyMeasurements,
   apiRequestLogs,
+  todos,
 } from '../db/schema/index';
 
 // Identity & Auth
@@ -46,3 +47,7 @@ export type { MeasurementTypeKey };
 // API Request Logs
 export type ApiRequestLog = InferSelectModel<typeof apiRequestLogs>;
 export type NewApiRequestLog = InferInsertModel<typeof apiRequestLogs>;
+
+// Todos
+export type Todo = InferSelectModel<typeof todos>;
+export type NewTodo = InferInsertModel<typeof todos>;


### PR DESCRIPTION
- Add `todos` table schema (user-scoped) with Drizzle migration
- Add todo service layer: getTodos, getOpenTodos, addTodo, markTodoDone, deleteAllUserTodos
- Add todo MCP server at /mcp/todo with tools (todo_add, todo_mark_done, todo_list) and todo://open resource
- Add Hub API routes: GET/POST /api/todo and PATCH /api/todo/[id]
- Add /todo page with add form and open/done tables
- Add Todo tile to home page
- Add 'todos' feature to delete-data API route
- Add Playwright e2e spec (8 tests) for the Todo UI
- Add Vitest e2e spec (7 tests) for the todo MCP server