### PR TITLE
Temporarily disable OAuth redirect URI validation for debugging

### DIFF
--- a/packages/mcp-server/src/routes/oauth.ts
+++ b/packages/mcp-server/src/routes/oauth.ts
@@ -31,20 +31,24 @@ function validateRedirectUri(redirectUri: string): URL | null {
     return null;
   }
 
-  const allowlist = envConfig.ALLOWED_REDIRECT_URIS;
-  if (allowlist.length > 0) {
-    const allowed = allowlist.some((entry) => redirectUri === entry || redirectUri.startsWith(entry));
-    return allowed ? parsed : null;
-  }
+  // TODO: Re-enable redirect URI allowlist/HTTPS validation once the OAuth
+  //       flow with Claude.ai is fully debugged.
+  // const allowlist = envConfig.ALLOWED_REDIRECT_URIS;
+  // if (allowlist.length > 0) {
+  //   const allowed = allowlist.some((entry) => redirectUri === entry || redirectUri.startsWith(entry));
+  //   return allowed ? parsed : null;
+  // }
+  //
+  // if (parsed.protocol === 'https:') return parsed;
+  // if (
+  //   parsed.protocol === 'http:' &&
+  //   (parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1' || parsed.hostname === '[::1]')
+  // ) {
+  //   return parsed;
+  // }
+  // return null;
 
-  if (parsed.protocol === 'https:') return parsed;
-  if (
-    parsed.protocol === 'http:' &&
-    (parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1' || parsed.hostname === '[::1]')
-  ) {
-    return parsed;
-  }
-  return null;
+  return parsed;
 }
 
 function escapeHtml(s: string): string {


### PR DESCRIPTION
## Summary
Temporarily disabled redirect URI allowlist and HTTPS protocol validation in the OAuth flow to facilitate debugging of the Claude.ai integration.

## Changes
- Commented out the `validateRedirectUri()` function's allowlist validation logic that checks against `ALLOWED_REDIRECT_URIS` environment configuration
- Commented out HTTPS protocol enforcement and localhost/127.0.0.1/[::1] validation for HTTP connections
- Modified the function to unconditionally return the parsed redirect URI without validation checks
- Added a TODO comment indicating this is a temporary measure pending completion of OAuth flow debugging with Claude.ai

## Notes
This is a temporary debugging change. The security-critical redirect URI validation should be re-enabled once the OAuth flow integration is fully debugged and working as expected.

https://claude.ai/code/session_01XYm5SMRMzF4yC2EVFCdRxg