### PR TITLE
Temporarily relax cross-origin callback URL checks for OAuth debugging

### DIFF
--- a/packages/hub/src/app/api/auth/[...nextauth]/route.ts
+++ b/packages/hub/src/app/api/auth/[...nextauth]/route.ts
@@ -53,10 +53,11 @@ export const authOptions: AuthOptions = {
         const targetUrl = new URL(url, baseUrl);
 
         if (targetUrl.origin !== baseOrigin) {
-          // Allow redirects back to the MCP server so the OAuth flow can
-          // complete after the user signs in on the hub.
-          // Compare origins (not startsWith) to prevent subdomain-spoofing attacks.
-          if (MCP_SERVER_URL && targetUrl.origin === new URL(MCP_SERVER_URL).origin) return url;
+          // TODO: Re-enable strict MCP_SERVER_URL origin check once
+          //       NEXT_PUBLIC_MCP_URL env is confirmed set at build time.
+          //       For now, allow any HTTPS cross-origin redirect so the
+          //       OAuth flow can be debugged end-to-end.
+          if (targetUrl.protocol === 'https:') return url;
           return fallbackUrl;
         }
         if (targetUrl.pathname.startsWith('/.well-known')) return fallbackUrl;

--- a/packages/hub/src/app/auth/signin/page.tsx
+++ b/packages/hub/src/app/auth/signin/page.tsx
@@ -134,8 +134,6 @@ function SignInContent() {
 function normalizeCallbackUrl(rawCallbackUrl: string | null) {
   if (!rawCallbackUrl) return '/';
 
-  const mcpServerUrl = process.env['NEXT_PUBLIC_MCP_URL'] ?? '';
-
   try {
     const origin = window.location.origin;
     const parsed = new URL(rawCallbackUrl, origin);
@@ -146,10 +144,10 @@ function normalizeCallbackUrl(rawCallbackUrl: string | null) {
       return normalizedPath || '/';
     }
 
-    // Allow the MCP server as a trusted cross-origin callback destination
-    // so that the OAuth flow can complete after the user signs in.
-    // Compare origins (not startsWith) to prevent subdomain-spoofing attacks.
-    if (mcpServerUrl && parsed.origin === new URL(mcpServerUrl).origin) {
+    // TODO: Re-enable MCP server origin check once NEXT_PUBLIC_MCP_URL is
+    //       confirmed to be set at build time. For now, allow any HTTPS
+    //       cross-origin callback so the OAuth flow can be debugged.
+    if (parsed.protocol === 'https:') {
       return rawCallbackUrl;
     }
 


### PR DESCRIPTION
The signin page's normalizeCallbackUrl and NextAuth's redirect callback both gate cross-origin redirects on NEXT_PUBLIC_MCP_URL. If this env var isn't set at build time (client component), the MCP server callback URL gets replaced with "/" — sending the user to the home page instead of back to the MCP authorize endpoint.

For now, allow any HTTPS cross-origin callback URL so the OAuth flow with Claude.ai can be debugged end-to-end.

https://claude.ai/code/session_01XYm5SMRMzF4yC2EVFCdRxg