### PR TITLE
fix(hub): keep finance modals and bottom sheets above mobile keyboard

### DIFF
--- a/packages/hub/src/app/finances/FinModalShell.tsx
+++ b/packages/hub/src/app/finances/FinModalShell.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components';
 
@@ -39,6 +39,8 @@ export function FinModalShell({
   submitDisabled,
   submitLoading,
 }: FinModalShellProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
   useEffect(() => {
     const prev = document.body.style.overflow;
     document.body.style.overflow = 'hidden';
@@ -47,9 +49,25 @@ export function FinModalShell({
     };
   }, []);
 
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const handle = (e: FocusEvent) => {
+      const t = e.target as HTMLElement;
+      if (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA') {
+        setTimeout(() => t.scrollIntoView({ block: 'nearest', behavior: 'smooth' }), 300);
+      }
+    };
+    el.addEventListener('focusin', handle);
+    return () => el.removeEventListener('focusin', handle);
+  }, []);
+
   return (
-    <div className="fin-modal-shell finances-theme fixed inset-0 z-[1000] flex flex-col bg-[var(--fin-card)] md:items-center md:justify-center md:bg-[var(--fin-overlay)] md:p-4">
-      {/* Desktop backdrop — absolutely positioned so it doesn't affect flex layout */}
+    <div
+      ref={containerRef}
+      className="fin-modal-shell finances-theme fixed inset-x-0 top-0 h-[100dvh] z-[1000] flex flex-col bg-[var(--fin-card)] md:inset-0 md:h-auto md:items-center md:justify-center md:bg-[var(--fin-overlay)] md:p-4"
+    >
+      {/* Desktop backdrop — absolute so it doesn't affect flex layout */}
       <div className="absolute inset-0 hidden md:block" onClick={onClose} />
 
       {/* Mobile header */}

--- a/packages/hub/src/app/finances/MobileSelectSheet.tsx
+++ b/packages/hub/src/app/finances/MobileSelectSheet.tsx
@@ -77,9 +77,9 @@ export function MobileSelectSheet({
   const canClear = clearable && value != null;
 
   return createPortal(
-    <div className="finances-theme fixed inset-0 z-[1100] flex flex-col justify-end bg-black/60" onClick={onClose}>
+    <div className="finances-theme fixed inset-x-0 top-0 h-[100dvh] z-[1100] flex flex-col justify-end bg-black/60" onClick={onClose}>
       <div
-        className="fin-slide-up flex max-h-[80vh] flex-col rounded-t-[18px] border border-[var(--fin-border)] bg-[var(--fin-card)]"
+        className="fin-slide-up flex max-h-[80dvh] flex-col rounded-t-[18px] border border-[var(--fin-border)] bg-[var(--fin-card)]"
         onClick={e => e.stopPropagation()}
       >
         {/* Header */}


### PR DESCRIPTION
Use `h-[100dvh]` (dynamic viewport height) instead of `fixed inset-0`
on mobile so that FinModalShell and MobileSelectSheet automatically
shrink when the software keyboard opens, keeping inputs and the
submit footer always visible above the keyboard.

Also adds a scoped `focusin` listener in FinModalShell that calls
`scrollIntoView` on focused inputs after a 300 ms delay, ensuring
content scrolls to show the active field after the keyboard animation.

https://claude.ai/code/session_016UPbP4B9Jj7UfsXhLJRSmp