### PR TITLE
feat(hub): account page icon buttons, archive confirm modal, full-width mobile ledger, searchable payee merge

### DIFF
--- a/packages/hub/src/app/finances/accounts/AccountDetailView.tsx
+++ b/packages/hub/src/app/finances/accounts/AccountDetailView.tsx
@@ -2,10 +2,11 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import { useRouter, useParams } from 'next/navigation';
-import { Pill, Button } from '@/components';
+import { Pill } from '@/components';
+import { PlusOutlineIcon, PencilIcon, ArchiveBoxIcon } from '@/components/icons';
 import { cn } from '@/lib/utils';
 import { apiFetch } from '@/lib/utils';
-import { fmt, Card, SectionLabel, Bar, TYPE_META } from '../ui';
+import { fmt, SectionLabel, Bar, TYPE_META } from '../ui';
 import { TransactionList } from '../transactions/TransactionList';
 import { EditAccountModal } from './EditAccountModal';
 import type { AccountItem } from '@/app/api/finances/accounts/route';
@@ -173,6 +174,65 @@ function CorrectionModal({
   );
 }
 
+function ArchiveConfirmModal({
+  name,
+  isArchived,
+  onClose,
+  onConfirm,
+}: {
+  name: string;
+  isArchived: boolean;
+  onClose: () => void;
+  onConfirm: () => Promise<void>;
+}) {
+  const [confirming, setConfirming] = useState(false);
+
+  async function handle() {
+    setConfirming(true);
+    try {
+      await onConfirm();
+    } finally {
+      setConfirming(false);
+    }
+  }
+
+  return (
+    <div
+      onClick={onClose}
+      className="fixed inset-0 z-[1000] flex items-center justify-center p-4 bg-[var(--fin-overlay)]"
+    >
+      <div
+        onClick={e => e.stopPropagation()}
+        className="flex w-full max-w-[360px] flex-col gap-4 rounded-[14px] border border-[var(--fin-border)] bg-[var(--fin-card)] p-5"
+      >
+        <div className="text-base font-bold text-[var(--fin-text)]">
+          {isArchived ? 'Unarchive Account' : 'Archive Account'}
+        </div>
+        <p className="text-[13px] text-[var(--fin-muted)]">
+          {isArchived
+            ? `Restore "${name}" so it appears in the main accounts list?`
+            : `Archive "${name}"? It will be hidden from the main list but can be restored later.`}
+        </p>
+        <div className="flex gap-2">
+          <button
+            onClick={onClose}
+            className="flex-1 cursor-pointer rounded-lg border border-[var(--fin-border)] bg-[var(--fin-card2)] py-2.5 text-[13px] font-semibold text-[var(--fin-muted)]"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handle}
+            disabled={confirming}
+            className="flex-[2] cursor-pointer rounded-lg border-none bg-amber-500/20 py-2.5 text-[13px] font-bold text-amber-400 transition-colors hover:bg-amber-500/30 disabled:opacity-50"
+          >
+            {confirming ? 'Saving…' : isArchived ? 'Unarchive' : 'Archive'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function TypeBadge({ type }: { type: string }) {
   const meta = TYPE_META[type] ?? { label: type, color: 'var(--fin-muted)' };
   return <Pill label={meta.label} color={meta.color} />;
@@ -304,6 +364,7 @@ export function AccountDetailView({ backPath }: AccountDetailViewProps) {
   const [loading, setLoading] = useState(!isNaN(numericId));
   const [correctionOpen, setCorrectionOpen] = useState(false);
   const [editOpen, setEditOpen] = useState(false);
+  const [archiveConfirmOpen, setArchiveConfirmOpen] = useState(false);
 
   const load = useCallback(async () => {
     const result = await apiFetch<AccountDetailData>(`/api/finances/accounts/${params.id}`, { silentToast: true });
@@ -343,6 +404,7 @@ export function AccountDetailView({ backPath }: AccountDetailViewProps) {
       body: { action: acc.archived ? 'unarchive' : 'archive' },
       silentToast: true,
     });
+    setArchiveConfirmOpen(false);
     load();
   }
 
@@ -359,20 +421,30 @@ export function AccountDetailView({ backPath }: AccountDetailViewProps) {
           <TypeBadge type={acc.type} />
         </div>
         <div className="flex items-center gap-1.5">
-          <Button size="xs" variant="primary" onClick={() => setCorrectionOpen(true)}>
-            + Correction
-          </Button>
-          <Button size="xs" variant="ghost" onClick={() => setEditOpen(true)}>
-            Edit
-          </Button>
-          <Button
-            size="xs"
-            variant="ghost"
-            className="text-amber-400 hover:text-amber-300 hover:bg-amber-900/20"
-            onClick={handleArchive}
+          <button
+            onClick={() => setCorrectionOpen(true)}
+            title="Balance Correction"
+            aria-label="Balance Correction"
+            className="flex h-7 w-7 cursor-pointer items-center justify-center rounded-md border border-[var(--fin-border)] bg-transparent text-[var(--fin-muted)] transition-colors hover:bg-[var(--fin-card2)] hover:text-[var(--fin-text)]"
           >
-            {acc.archived ? 'Unarchive' : 'Archive'}
-          </Button>
+            <PlusOutlineIcon className="size-3.5" />
+          </button>
+          <button
+            onClick={() => setEditOpen(true)}
+            title="Edit account"
+            aria-label="Edit account"
+            className="flex h-7 w-7 cursor-pointer items-center justify-center rounded-md border border-[var(--fin-border)] bg-transparent text-[var(--fin-muted)] transition-colors hover:bg-[var(--fin-card2)] hover:text-[var(--fin-text)]"
+          >
+            <PencilIcon className="size-3.5" />
+          </button>
+          <button
+            onClick={() => setArchiveConfirmOpen(true)}
+            title={acc.archived ? 'Unarchive account' : 'Archive account'}
+            aria-label={acc.archived ? 'Unarchive account' : 'Archive account'}
+            className="flex h-7 w-7 cursor-pointer items-center justify-center rounded-md border border-[var(--fin-border)] bg-transparent text-amber-400 transition-colors hover:bg-amber-900/20 hover:text-amber-300"
+          >
+            <ArchiveBoxIcon className="size-3.5" />
+          </button>
         </div>
       </div>
 
@@ -388,10 +460,10 @@ export function AccountDetailView({ backPath }: AccountDetailViewProps) {
         </button>
       )}
 
-      <Card className="p-[14px]">
-        <SectionLabel className="mb-2.5">Ledger</SectionLabel>
+      <div className="-mx-7 border-y border-[var(--fin-border)] bg-[var(--fin-card)] md:mx-0 md:rounded-[10px] md:border md:p-[14px]">
+        <SectionLabel className="mb-2.5 mt-[14px] px-[14px] md:mt-0 md:px-0">Ledger</SectionLabel>
         <TransactionList transactions={transactions} currency={acc.currency} />
-      </Card>
+      </div>
 
       {editOpen && (
         <EditAccountModal
@@ -401,6 +473,15 @@ export function AccountDetailView({ backPath }: AccountDetailViewProps) {
             setEditOpen(false);
             load();
           }}
+        />
+      )}
+
+      {archiveConfirmOpen && (
+        <ArchiveConfirmModal
+          name={acc.name}
+          isArchived={!!acc.archived}
+          onClose={() => setArchiveConfirmOpen(false)}
+          onConfirm={handleArchive}
         />
       )}
 

--- a/packages/hub/src/app/finances/accounts/AccountDetailView.tsx
+++ b/packages/hub/src/app/finances/accounts/AccountDetailView.tsx
@@ -2,11 +2,11 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import { useRouter, useParams } from 'next/navigation';
-import { Pill } from '@/components';
+import { Pill, IconButton } from '@/components';
 import { PlusOutlineIcon, PencilIcon, ArchiveBoxIcon } from '@/components/icons';
-import { cn } from '@/lib/utils';
-import { apiFetch } from '@/lib/utils';
+import { cn, apiFetch } from '@/lib/utils';
 import { fmt, SectionLabel, Bar, TYPE_META } from '../ui';
+import { FinModalShell } from '../FinModalShell';
 import { TransactionList } from '../transactions/TransactionList';
 import { EditAccountModal } from './EditAccountModal';
 import type { AccountItem } from '@/app/api/finances/accounts/route';
@@ -197,39 +197,20 @@ function ArchiveConfirmModal({
   }
 
   return (
-    <div
-      onClick={onClose}
-      className="fixed inset-0 z-[1000] flex items-center justify-center p-4 bg-[var(--fin-overlay)]"
+    <FinModalShell
+      onClose={onClose}
+      title={isArchived ? 'Unarchive Account' : 'Archive Account'}
+      className="md:max-w-[360px]"
+      onSubmit={handle}
+      submitLabel={isArchived ? 'Unarchive' : 'Archive'}
+      submitLoading={confirming}
     >
-      <div
-        onClick={e => e.stopPropagation()}
-        className="flex w-full max-w-[360px] flex-col gap-4 rounded-[14px] border border-[var(--fin-border)] bg-[var(--fin-card)] p-5"
-      >
-        <div className="text-base font-bold text-[var(--fin-text)]">
-          {isArchived ? 'Unarchive Account' : 'Archive Account'}
-        </div>
-        <p className="text-[13px] text-[var(--fin-muted)]">
-          {isArchived
-            ? `Restore "${name}" so it appears in the main accounts list?`
-            : `Archive "${name}"? It will be hidden from the main list but can be restored later.`}
-        </p>
-        <div className="flex gap-2">
-          <button
-            onClick={onClose}
-            className="flex-1 cursor-pointer rounded-lg border border-[var(--fin-border)] bg-[var(--fin-card2)] py-2.5 text-[13px] font-semibold text-[var(--fin-muted)]"
-          >
-            Cancel
-          </button>
-          <button
-            onClick={handle}
-            disabled={confirming}
-            className="flex-[2] cursor-pointer rounded-lg border-none bg-amber-500/20 py-2.5 text-[13px] font-bold text-amber-400 transition-colors hover:bg-amber-500/30 disabled:opacity-50"
-          >
-            {confirming ? 'Saving…' : isArchived ? 'Unarchive' : 'Archive'}
-          </button>
-        </div>
-      </div>
-    </div>
+      <p className="text-[13px] text-[var(--fin-muted)]">
+        {isArchived
+          ? `Restore "${name}" so it appears in the main accounts list?`
+          : `Archive "${name}"? It will be hidden from the main list but can be restored later.`}
+      </p>
+    </FinModalShell>
   );
 }
 
@@ -421,30 +402,24 @@ export function AccountDetailView({ backPath }: AccountDetailViewProps) {
           <TypeBadge type={acc.type} />
         </div>
         <div className="flex items-center gap-1.5">
-          <button
+          <IconButton
+            label="Balance Correction"
+            icon={<PlusOutlineIcon className="size-3.5" />}
             onClick={() => setCorrectionOpen(true)}
-            title="Balance Correction"
-            aria-label="Balance Correction"
-            className="flex h-7 w-7 cursor-pointer items-center justify-center rounded-md border border-[var(--fin-border)] bg-transparent text-[var(--fin-muted)] transition-colors hover:bg-[var(--fin-card2)] hover:text-[var(--fin-text)]"
-          >
-            <PlusOutlineIcon className="size-3.5" />
-          </button>
-          <button
+            className="h-7 w-7 flex items-center justify-center p-0 border border-[var(--fin-border)] bg-transparent text-[var(--fin-muted)] hover:bg-[var(--fin-card2)] hover:text-[var(--fin-text)]"
+          />
+          <IconButton
+            label="Edit account"
+            icon={<PencilIcon className="size-3.5" />}
             onClick={() => setEditOpen(true)}
-            title="Edit account"
-            aria-label="Edit account"
-            className="flex h-7 w-7 cursor-pointer items-center justify-center rounded-md border border-[var(--fin-border)] bg-transparent text-[var(--fin-muted)] transition-colors hover:bg-[var(--fin-card2)] hover:text-[var(--fin-text)]"
-          >
-            <PencilIcon className="size-3.5" />
-          </button>
-          <button
+            className="h-7 w-7 flex items-center justify-center p-0 border border-[var(--fin-border)] bg-transparent text-[var(--fin-muted)] hover:bg-[var(--fin-card2)] hover:text-[var(--fin-text)]"
+          />
+          <IconButton
+            label={acc.archived ? 'Unarchive account' : 'Archive account'}
+            icon={<ArchiveBoxIcon className="size-3.5" />}
             onClick={() => setArchiveConfirmOpen(true)}
-            title={acc.archived ? 'Unarchive account' : 'Archive account'}
-            aria-label={acc.archived ? 'Unarchive account' : 'Archive account'}
-            className="flex h-7 w-7 cursor-pointer items-center justify-center rounded-md border border-[var(--fin-border)] bg-transparent text-amber-400 transition-colors hover:bg-amber-900/20 hover:text-amber-300"
-          >
-            <ArchiveBoxIcon className="size-3.5" />
-          </button>
+            className="h-7 w-7 flex items-center justify-center p-0 border border-[var(--fin-border)] bg-transparent text-amber-400 hover:bg-amber-900/20 hover:text-amber-300"
+          />
         </div>
       </div>
 

--- a/packages/hub/src/app/finances/payees/MergePayeeModal.tsx
+++ b/packages/hub/src/app/finances/payees/MergePayeeModal.tsx
@@ -1,9 +1,11 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 import { apiFetch } from '@/lib/utils';
+import { cn } from '@/lib/utils';
 import { FinModalShell } from '../FinModalShell';
-import { Field, Select } from '@/components';
+import { Field } from '@/components';
+import { ChevronDownOutlineIcon } from '@/components/icons';
 import type { PayeeWithSuggestion } from '@/app/api/finances/payees/route';
 
 type MergePayeeModalProps = {
@@ -12,6 +14,86 @@ type MergePayeeModalProps = {
   onClose: () => void;
   onMerged: () => void;
 };
+
+function SearchablePayeeSelect({
+  payees,
+  value,
+  onChange,
+}: {
+  payees: PayeeWithSuggestion[];
+  value: number | '';
+  onChange: (id: number | '') => void;
+}) {
+  const [query, setQuery] = useState('');
+  const [open, setOpen] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const selected = payees.find(p => p.id === value);
+
+  const filtered = query.trim()
+    ? payees.filter(p => p.name.toLowerCase().includes(query.toLowerCase()))
+    : payees;
+
+  function handleSelect(id: number) {
+    onChange(id);
+    setOpen(false);
+    setQuery('');
+  }
+
+  return (
+    <div className="relative">
+      <div
+        className="flex cursor-text items-center gap-2 rounded-lg border border-[var(--fin-border)] bg-[var(--fin-card2)] px-3 py-2.5"
+        onClick={() => inputRef.current?.focus()}
+      >
+        <input
+          ref={inputRef}
+          type="text"
+          className="flex-1 bg-transparent text-[13px] text-[var(--fin-text)] outline-none placeholder:text-[var(--fin-subtle)]"
+          placeholder={selected ? selected.name : 'Search payee…'}
+          value={open ? query : (selected?.name ?? '')}
+          onChange={e => {
+            setQuery(e.target.value);
+            setOpen(true);
+          }}
+          onFocus={() => {
+            setQuery('');
+            setOpen(true);
+          }}
+          onBlur={() => setTimeout(() => setOpen(false), 150)}
+        />
+        <ChevronDownOutlineIcon
+          className={cn(
+            'size-3.5 shrink-0 text-[var(--fin-subtle)] transition-transform duration-150',
+            open && 'rotate-180',
+          )}
+        />
+      </div>
+
+      {open && (
+        <div className="absolute z-20 mt-1 max-h-48 w-full overflow-y-auto rounded-lg border border-[var(--fin-border)] bg-[var(--fin-card)] shadow-lg">
+          {filtered.length === 0 ? (
+            <div className="px-3 py-3 text-center text-[12px] text-[var(--fin-subtle)]">No payees found</div>
+          ) : (
+            filtered.map(p => (
+              <button
+                key={p.id}
+                type="button"
+                onMouseDown={() => handleSelect(p.id)}
+                className={cn(
+                  'flex w-full items-center px-3 py-2 text-left text-[13px] transition-colors hover:bg-[var(--fin-card2)]',
+                  p.id === value ? 'font-semibold text-[var(--fin-text)]' : 'text-[var(--fin-muted)]',
+                )}
+              >
+                {p.name}
+              </button>
+            ))
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
 
 export function MergePayeeModal({ payee, allPayees, onClose, onMerged }: MergePayeeModalProps) {
   const [sourceId, setSourceId] = useState<number | ''>('');
@@ -53,13 +135,7 @@ export function MergePayeeModal({ payee, allPayees, onClose, onMerged }: MergePa
         </p>
 
         <Field label="Payee to merge in">
-          <Select
-            value={sourceId}
-            onChange={e => setSourceId(e.target.value ? Number(e.target.value) : '')}
-            options={options.map(p => ({ value: p.id, label: p.name }))}
-          >
-            <option value="">Select payee…</option>
-          </Select>
+          <SearchablePayeeSelect payees={options} value={sourceId} onChange={setSourceId} />
         </Field>
 
         {error && <p className="text-xs text-red-400">{error}</p>}

--- a/packages/hub/src/app/finances/payees/MergePayeeModal.tsx
+++ b/packages/hub/src/app/finances/payees/MergePayeeModal.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { useState, useRef, useMemo } from 'react';
-import { apiFetch, cn } from '@/lib/utils';
+import { useState } from 'react';
+import { apiFetch } from '@/lib/utils';
 import { FinModalShell } from '../FinModalShell';
 import { Field } from '@/components';
-import { ChevronDownOutlineIcon } from '@/components/icons';
+import { FinancialDropdown, type DropdownOption } from '../FinancialDropdown';
 import type { PayeeWithSuggestion } from '@/app/api/finances/payees/route';
 
 type MergePayeeModalProps = {
@@ -14,96 +14,14 @@ type MergePayeeModalProps = {
   onMerged: () => void;
 };
 
-function SearchablePayeeSelect({
-  payees,
-  value,
-  onChange,
-}: {
-  payees: PayeeWithSuggestion[];
-  value: number | '';
-  onChange: (id: number | '') => void;
-}) {
-  const [query, setQuery] = useState('');
-  const [open, setOpen] = useState(false);
-  const inputRef = useRef<HTMLInputElement>(null);
-  const blurTimeout = useRef<ReturnType<typeof setTimeout>>();
-
-  const selected = useMemo(() => payees.find(p => p.id === value), [payees, value]);
-
-  const filtered = useMemo(
-    () =>
-      query.trim() ? payees.filter(p => p.name.toLowerCase().includes(query.toLowerCase())) : payees,
-    [payees, query],
-  );
-
-  function handleSelect(id: number) {
-    clearTimeout(blurTimeout.current);
-    onChange(id);
-    setOpen(false);
-    setQuery('');
-  }
-
-  return (
-    <div className="relative">
-      <div
-        className="flex cursor-text items-center gap-2 rounded-lg border border-[var(--fin-border)] bg-[var(--fin-card2)] px-3 py-2.5"
-        onClick={() => inputRef.current?.focus()}
-      >
-        <input
-          ref={inputRef}
-          type="text"
-          className="flex-1 bg-transparent text-[13px] text-[var(--fin-text)] outline-none placeholder:text-[var(--fin-subtle)]"
-          placeholder={selected ? selected.name : 'Search payee…'}
-          value={open ? query : (selected?.name ?? '')}
-          onChange={e => {
-            setQuery(e.target.value);
-            setOpen(true);
-          }}
-          onFocus={() => {
-            setQuery('');
-            setOpen(true);
-          }}
-          onBlur={() => { blurTimeout.current = setTimeout(() => setOpen(false), 150); }}
-        />
-        <ChevronDownOutlineIcon
-          className={cn(
-            'size-3.5 shrink-0 text-[var(--fin-subtle)] transition-transform duration-150',
-            open && 'rotate-180',
-          )}
-        />
-      </div>
-
-      {open && (
-        <div className="absolute z-20 mt-1 max-h-48 w-full overflow-y-auto rounded-lg border border-[var(--fin-border)] bg-[var(--fin-card)] shadow-lg">
-          {filtered.length === 0 ? (
-            <div className="px-3 py-3 text-center text-[12px] text-[var(--fin-subtle)]">No payees found</div>
-          ) : (
-            filtered.map(p => (
-              <button
-                key={p.id}
-                type="button"
-                onMouseDown={() => handleSelect(p.id)}
-                className={cn(
-                  'flex w-full items-center px-3 py-2 text-left text-[13px] transition-colors hover:bg-[var(--fin-card2)]',
-                  p.id === value ? 'font-semibold text-[var(--fin-text)]' : 'text-[var(--fin-muted)]',
-                )}
-              >
-                {p.name}
-              </button>
-            ))
-          )}
-        </div>
-      )}
-    </div>
-  );
-}
-
 export function MergePayeeModal({ payee, allPayees, onClose, onMerged }: MergePayeeModalProps) {
-  const [sourceId, setSourceId] = useState<number | ''>('');
+  const [sourceId, setSourceId] = useState<number | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const options = allPayees.filter(p => p.id !== payee.id);
+  const options: DropdownOption[] = allPayees
+    .filter(p => p.id !== payee.id)
+    .map(p => ({ id: p.id, value: p.name }));
 
   async function handleSubmit() {
     if (!sourceId) return;
@@ -138,7 +56,13 @@ export function MergePayeeModal({ payee, allPayees, onClose, onMerged }: MergePa
         </p>
 
         <Field label="Payee to merge in">
-          <SearchablePayeeSelect payees={options} value={sourceId} onChange={setSourceId} />
+          <FinancialDropdown
+            options={options}
+            value={sourceId ?? undefined}
+            onChange={item => setSourceId(item ? Number(item.id) : null)}
+            placeholder="Search payee…"
+            noResultsText="No payees found"
+          />
         </Field>
 
         {error && <p className="text-xs text-red-400">{error}</p>}

--- a/packages/hub/src/app/finances/payees/MergePayeeModal.tsx
+++ b/packages/hub/src/app/finances/payees/MergePayeeModal.tsx
@@ -1,8 +1,7 @@
 'use client';
 
-import { useState, useRef } from 'react';
-import { apiFetch } from '@/lib/utils';
-import { cn } from '@/lib/utils';
+import { useState, useRef, useMemo } from 'react';
+import { apiFetch, cn } from '@/lib/utils';
 import { FinModalShell } from '../FinModalShell';
 import { Field } from '@/components';
 import { ChevronDownOutlineIcon } from '@/components/icons';
@@ -27,14 +26,18 @@ function SearchablePayeeSelect({
   const [query, setQuery] = useState('');
   const [open, setOpen] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
+  const blurTimeout = useRef<ReturnType<typeof setTimeout>>();
 
-  const selected = payees.find(p => p.id === value);
+  const selected = useMemo(() => payees.find(p => p.id === value), [payees, value]);
 
-  const filtered = query.trim()
-    ? payees.filter(p => p.name.toLowerCase().includes(query.toLowerCase()))
-    : payees;
+  const filtered = useMemo(
+    () =>
+      query.trim() ? payees.filter(p => p.name.toLowerCase().includes(query.toLowerCase())) : payees,
+    [payees, query],
+  );
 
   function handleSelect(id: number) {
+    clearTimeout(blurTimeout.current);
     onChange(id);
     setOpen(false);
     setQuery('');
@@ -60,7 +63,7 @@ function SearchablePayeeSelect({
             setQuery('');
             setOpen(true);
           }}
-          onBlur={() => setTimeout(() => setOpen(false), 150)}
+          onBlur={() => { blurTimeout.current = setTimeout(() => setOpen(false), 150); }}
         />
         <ChevronDownOutlineIcon
           className={cn(

--- a/packages/hub/src/app/finances/transactions/TransactionList.tsx
+++ b/packages/hub/src/app/finances/transactions/TransactionList.tsx
@@ -127,7 +127,7 @@ export function TransactionList({
                 onEdit={onEdit ? () => onEdit(tx.id) : undefined}
                 onDelete={onDelete ? () => onDelete(tx.id) : undefined}
               >
-                <div className="flex items-center gap-2.5 py-2.5 pr-2">
+                <div className="flex items-center gap-2.5 py-2.5 pl-[14px] pr-[14px] md:pl-0 md:pr-2">
                   {/* Left: icon */}
                   <CategoryIcon color={catColor} size="sm">
                     {tx.isCorrection ? '⚖' : isTransfer ? '↔' : categoryIconEmoji(tx.categoryIcon)}

--- a/packages/hub/src/components/icons/ArchiveBoxIcon.tsx
+++ b/packages/hub/src/components/icons/ArchiveBoxIcon.tsx
@@ -1,0 +1,21 @@
+import { cn } from '@/lib/utils';
+import { IconProps } from './types';
+
+export function ArchiveBoxIcon({ className }: IconProps = {}) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={cn('size-4', className)}
+      aria-hidden="true"
+    >
+      <rect x="2" y="4" width="20" height="5" rx="1" />
+      <path d="M4 9v10a1 1 0 0 0 1 1h14a1 1 0 0 0 1-1V9" />
+      <path d="M10 14h4" />
+    </svg>
+  );
+}

--- a/packages/hub/src/components/icons/index.ts
+++ b/packages/hub/src/components/icons/index.ts
@@ -39,3 +39,4 @@ export { SpinnerIcon } from './SpinnerIcon';
 export { EyeOutlineIcon } from './EyeOutlineIcon';
 export { EyeOffOutlineIcon } from './EyeOffOutlineIcon';
 export { QuestionMarkIcon } from './QuestionMarkIcon';
+export { ArchiveBoxIcon } from './ArchiveBoxIcon';


### PR DESCRIPTION
- Replace Correction/Edit/Archive text buttons on account detail with icon-only buttons (PlusOutline, Pencil, ArchiveBox)
- Add ArchiveConfirmModal with cancel/confirm flow instead of immediate archive on click
- Add new ArchiveBoxIcon SVG component
- Make transactions ledger section full-bleed on mobile (negative margin, border-y only, no padding)
- Add left/right padding to TransactionList mobile rows to compensate for removed card padding
- Replace plain Select in MergePayeeModal with SearchablePayeeSelect combobox (filter-as-you-type dropdown)

https://claude.ai/code/session_01CVFgqA5BfaTc3jLHzuJDCk