### PR TITLE
feat(travel): add meal type to accommodation reservations and surface import source

### DIFF
--- a/packages/hub/src/app/travel/BookingExpandedPanel.tsx
+++ b/packages/hub/src/app/travel/BookingExpandedPanel.tsx
@@ -1,7 +1,14 @@
 'use client';
 
-import { Fragment } from 'react';
-import type { BookingDetails, FlightDetails, TransportDetails, TripDocument } from '@my-hub/shared/types';
+import { Fragment, useState } from 'react';
+import type {
+  AccommodationDetails,
+  BookingDetails,
+  FlightDetails,
+  MealType,
+  TransportDetails,
+  TripDocument,
+} from '@my-hub/shared/types';
 import type { TripBookingExtended } from './types';
 import { TravelTimeDisplay } from './TravelTimeDisplay';
 import { isTransportBookingType } from '@my-hub/shared/utils';
@@ -72,21 +79,67 @@ function ExtraDetailsSection({ booking }: { booking: TripBookingExtended }) {
   );
 }
 
+function MealTypeButton({ mealType }: { mealType: MealType }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        title="Meal plan included"
+        className="inline-flex items-center justify-center w-6 h-6 rounded-full bg-emerald-500/20 border border-emerald-500/40 text-emerald-400 hover:bg-emerald-500/30 transition-colors text-sm"
+      >
+        🍽
+      </button>
+      {open && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60" onClick={() => setOpen(false)}>
+          <div
+            className="bg-zinc-900 border border-zinc-700 rounded-xl p-5 max-w-xs w-full mx-4 shadow-2xl"
+            onClick={e => e.stopPropagation()}
+          >
+            <div className="flex items-center gap-2 mb-3">
+              <span className="text-lg">🍽</span>
+              <h3 className="text-sm font-semibold text-zinc-100">{mealType.short}</h3>
+            </div>
+            <p className="text-xs text-zinc-400 leading-relaxed">{mealType.description}</p>
+            <button
+              type="button"
+              onClick={() => setOpen(false)}
+              className="mt-4 text-[11px] text-zinc-500 hover:text-zinc-300 transition-colors"
+            >
+              Close
+            </button>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}
+
 function SourceTextSection({ booking }: { booking: TripBookingExtended }) {
   const d = booking.details as BookingDetails | null;
-  if (!d?.rawText) return null;
+  if (!d?.rawText && !d?.source) return null;
 
   return (
-    <details className="border-t border-zinc-700/40 pt-2 group">
-      <summary className="text-[11px] uppercase tracking-wide text-zinc-500 cursor-pointer select-none list-none flex items-center gap-1">
-        <span className="group-open:hidden">▸</span>
-        <span className="hidden group-open:inline">▾</span>
-        Source text
-      </summary>
-      <blockquote className="mt-1 text-xs text-zinc-400 italic leading-relaxed whitespace-pre-wrap">
-        {d.rawText}
-      </blockquote>
-    </details>
+    <div className="border-t border-zinc-700/40 pt-2 space-y-1">
+      {d.source && (
+        <p className="text-[11px] text-zinc-500">
+          Source: <span className="text-zinc-400">{d.source}</span>
+        </p>
+      )}
+      {d.rawText && (
+        <details className="group">
+          <summary className="text-[11px] uppercase tracking-wide text-zinc-500 cursor-pointer select-none list-none flex items-center gap-1">
+            <span className="group-open:hidden">▸</span>
+            <span className="hidden group-open:inline">▾</span>
+            Source text
+          </summary>
+          <blockquote className="mt-1 text-xs text-zinc-400 italic leading-relaxed whitespace-pre-wrap">
+            {d.rawText}
+          </blockquote>
+        </details>
+      )}
+    </div>
   );
 }
 
@@ -96,6 +149,11 @@ export function BookingExpandedPanel({ booking, documents }: BookingExpandedPane
       {booking.bookingType === 'flight' && <FlightDetailsPill booking={booking} />}
 
       {isTransportBookingType(booking.bookingType) && <TransportDetailsPill booking={booking} />}
+
+      {(booking.details as AccommodationDetails | null)?.kind === 'accommodation' &&
+        (booking.details as AccommodationDetails).mealType && (
+          <MealTypeButton mealType={(booking.details as AccommodationDetails).mealType!} />
+        )}
 
       <dl className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs">
         {booking.location && (

--- a/packages/hub/src/app/travel/BookingExpandedPanel.tsx
+++ b/packages/hub/src/app/travel/BookingExpandedPanel.tsx
@@ -12,6 +12,7 @@ import type {
 import type { TripBookingExtended } from './types';
 import { TravelTimeDisplay } from './TravelTimeDisplay';
 import { isTransportBookingType } from '@my-hub/shared/utils';
+import { IconButton } from '@/components';
 
 type BookingExpandedPanelProps = {
   booking: TripBookingExtended;
@@ -83,14 +84,12 @@ function MealTypeButton({ mealType }: { mealType: MealType }) {
   const [open, setOpen] = useState(false);
   return (
     <>
-      <button
-        type="button"
+      <IconButton
+        label="Meal plan included"
+        icon={<span>🍽</span>}
         onClick={() => setOpen(true)}
-        title="Meal plan included"
-        className="inline-flex items-center justify-center w-6 h-6 rounded-full bg-emerald-500/20 border border-emerald-500/40 text-emerald-400 hover:bg-emerald-500/30 transition-colors text-sm"
-      >
-        🍽
-      </button>
+        className="bg-emerald-500/20 border border-emerald-500/40 text-emerald-400 hover:bg-emerald-500/30 rounded-full p-1"
+      />
       {open && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60" onClick={() => setOpen(false)}>
           <div

--- a/packages/mcp-server/src/travel/tools/bookings.ts
+++ b/packages/mcp-server/src/travel/tools/bookings.ts
@@ -10,6 +10,7 @@ import {
   upsertFlightData,
 } from '@my-hub/shared/services';
 import type {
+  AccommodationDetails,
   BaseBookingDetails,
   FlightDetails,
   TransportDetails,
@@ -92,6 +93,23 @@ export const TravelAddReservationFromTextInputSchema = z.object({
     })
     .optional()
     .describe('Destination location for transport bookings. Extract from text when possible.'),
+  source: z
+    .string()
+    .optional()
+    .describe(
+      'Human-readable origin of this reservation — something that lets the user trace it back. For emails, use the subject line (e.g. "Your Hilton booking confirmation – Ref #12345"). For SMS, the sender name. For apps, the app name. Omit only if truly unknown.',
+    ),
+  mealType: z
+    .object({
+      short: z.string().describe('Short label shown in the UI, e.g. "BB", "HB", "AI", "Breakfast included".'),
+      description: z
+        .string()
+        .describe(
+          'Full description shown in the detail panel, e.g. "Bed & Breakfast — daily breakfast included in the room rate".',
+        ),
+    })
+    .optional()
+    .describe('Meal plan included with the reservation, if any. Primarily for hotels/accommodation.'),
   extra: z
     .record(z.string(), z.unknown())
     .optional()
@@ -134,22 +152,32 @@ export const travelAddReservationFromTextTool: ToolHandler<
       ? `${input.origin!.name} → ${input.destination!.name}`
       : `Imported ${bookingType} reservation`);
 
-  const details: TransportDetails | BaseBookingDetails =
+  const source = input.source ?? 'nl_import';
+
+  const details: TransportDetails | AccommodationDetails | BaseBookingDetails =
     isTransport && hasRoute
       ? {
           kind: 'transport',
           origin: input.origin as TransportLocation,
           destination: input.destination as TransportLocation,
-          source: 'nl_import',
+          source,
           rawText: input.bookingText,
           ...(input.extra && { extra: input.extra }),
         }
-      : {
-          kind: 'base',
-          source: 'nl_import',
-          rawText: input.bookingText,
-          ...(input.extra && { extra: input.extra }),
-        };
+      : bookingType === TripBookingTypes.Accommodation
+        ? {
+            kind: 'accommodation',
+            source,
+            rawText: input.bookingText,
+            ...(input.mealType && { mealType: input.mealType }),
+            ...(input.extra && { extra: input.extra }),
+          }
+        : {
+            kind: 'base',
+            source,
+            rawText: input.bookingText,
+            ...(input.extra && { extra: input.extra }),
+          };
 
   const booking = await addTripBooking(userId, input.tripId, {
     bookingType,

--- a/packages/shared/src/types/booking-details.ts
+++ b/packages/shared/src/types/booking-details.ts
@@ -3,8 +3,17 @@
 // Use BookingDetails as the root; extend for each booking type.
 // Use BaseBookingDetails for types without a dedicated shape yet.
 
+/** Meal plan included with a reservation (e.g. for hotels). */
+export interface MealType {
+  /** Short label shown in the UI, e.g. "BB", "HB", "AI", "Breakfast included". */
+  short: string;
+  /** Full explanation shown in the detail modal, e.g. "Bed & Breakfast – daily breakfast included". */
+  description: string;
+}
+
 export interface BookingDetails {
   readonly kind: string;
+  /** Human-readable import origin, e.g. an email subject or source app name. */
   source?: string;
   rawText?: string;
   /** Open bag — AI may add any extra fields it considers relevant. */
@@ -47,6 +56,12 @@ export interface TransportDetails extends BookingDetails {
   vesselName?: string;
   cabin?: string;
   distanceKm?: number;
+}
+
+// Accommodation booking details (hotel, hostel, apartment, etc.)
+export interface AccommodationDetails extends BookingDetails {
+  readonly kind: 'accommodation';
+  mealType?: MealType;
 }
 
 // Fallback shape for booking types without a dedicated details interface yet.

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -81,10 +81,12 @@ export type NewApiaryTask = InferInsertModel<typeof apiaryTasks>;
 
 // Travel — booking details discriminated union
 export type {
+  MealType,
   BookingDetails,
   FlightDetails,
   TransportLocation,
   TransportDetails,
+  AccommodationDetails,
   BaseBookingDetails,
 } from './booking-details';
 


### PR DESCRIPTION
- Add MealType interface and AccommodationDetails (kind: 'accommodation') to the
  booking-details discriminated union so meal plan info is typed to accommodation bookings
- Add mealType and source fields to travel_add_reservation_from_text MCP tool schema;
  instruct AI to supply a traceable source string (e.g. email subject line)
- Handler now uses kind: 'accommodation' for accommodation bookings and passes mealType through
- BookingExpandedPanel: MealTypeButton renders a green icon; click opens an inline modal
  showing the meal plan short label and description
- SourceTextSection now displays the source string above the collapsible raw-text block

https://claude.ai/code/session_01WzUHdqyFq4CyVv4QR2Qop3