### PR TITLE
Show category on transfer transactions (optional)

### DIFF
--- a/packages/hub/src/app/finances/transactions/TransactionModal.tsx
+++ b/packages/hub/src/app/finances/transactions/TransactionModal.tsx
@@ -236,7 +236,7 @@ export function TransactionModal({
       toAccountId: txType === TransactionTypes.Transfer ? selToAccId : null,
       amount: parseFloat(values.amount),
       date: values.date,
-      categoryId: txType === TransactionTypes.Transfer ? null : selCatId,
+      categoryId: selCatId,
       payeeName: values.payee.trim() || undefined,
       notes: values.note.trim() || undefined,
       labels: values.labels,
@@ -428,21 +428,35 @@ export function TransactionModal({
           )}
 
           {txType === TransactionTypes.Transfer ? (
-            <MobileFieldRow label="To Account">
-              {prefilledToAccountId != null ? (
-                <span className="text-[13px] font-medium text-[var(--fin-text)]">{prefilledToAccountName}</span>
-              ) : (
+            <>
+              <MobileFieldRow label="To Account">
+                {prefilledToAccountId != null ? (
+                  <span className="text-[13px] font-medium text-[var(--fin-text)]">{prefilledToAccountName}</span>
+                ) : (
+                  <FinancialDropdown
+                    searchable={false}
+                    options={toAccountOptions}
+                    value={selToAccId ?? undefined}
+                    onChange={item => setSelToAccId(item ? (item.id as number) : null)}
+                    renderOption={item => renderAccountOption(item, formData?.accounts ?? [])}
+                    placeholder="Choose..."
+                    inputClassName={mobileDropdownInputClass}
+                  />
+                )}
+              </MobileFieldRow>
+              <MobileFieldRow label="Category">
                 <FinancialDropdown
                   searchable={false}
-                  options={toAccountOptions}
-                  value={selToAccId ?? undefined}
-                  onChange={item => setSelToAccId(item ? (item.id as number) : null)}
-                  renderOption={item => renderAccountOption(item, formData?.accounts ?? [])}
-                  placeholder="Choose..."
+                  options={categoryOptions}
+                  value={selCatId ?? undefined}
+                  onChange={item => setSelCatId(item ? (item.id as number) : null)}
+                  clearable
+                  noResultsText="No categories yet — add one in the Categories tab."
+                  placeholder="⬡ Choose..."
                   inputClassName={mobileDropdownInputClass}
                 />
-              )}
-            </MobileFieldRow>
+              </MobileFieldRow>
+            </>
           ) : (
             <MobileFieldRow label="Category">
               <FinancialDropdown
@@ -637,6 +651,21 @@ export function TransactionModal({
                 </FieldCard>
               )}
             </div>
+
+            {txType === TransactionTypes.Transfer && (
+              <FieldCard label="Category">
+                <FinancialDropdown
+                  searchable={false}
+                  options={categoryOptions}
+                  value={selCatId ?? undefined}
+                  onChange={item => setSelCatId(item ? (item.id as number) : null)}
+                  clearable
+                  noResultsText="No categories yet — add one in the Categories tab."
+                  placeholder="⬡ Choose…"
+                  inputClassName="border-b-0 py-0 text-[13px] font-medium text-[var(--fin-text)] placeholder:text-[var(--fin-subtle)]"
+                />
+              </FieldCard>
+            )}
 
             <div className="grid grid-cols-2 gap-2">
               <FieldCard label="Date">

--- a/packages/mcp-server/src/finances/tools/tools.ts
+++ b/packages/mcp-server/src/finances/tools/tools.ts
@@ -129,6 +129,8 @@ const financeTools = [
       'Each item is processed independently — a duplicate warning on one does not block the others. ' +
       'Only populate the notes field when you have meaningful information to add. ' +
       'The tool automatically detects possible duplicates and includes a warning in the result if found. ' +
+      'categoryId is optional for all transaction types including transfers. ' +
+      'For loan repayments and other categorised transfers, set categoryId to track the spending. ' +
       'If a payeeName is not recognized and createPayee is false (default), the call returns a payee_not_found error — ' +
       'use finances_upsert_payee to create the payee first, or set createPayee: true to create it automatically. ' +
       '\n\nExtras field guidance:\n' +
@@ -146,7 +148,8 @@ const financeTools = [
     name: 'finances_update_transaction',
     description:
       'Edit an existing transaction. Only transactions you added can be updated. ' +
-      'Account balances are recomputed atomically when amount, account, or type changes.',
+      'Account balances are recomputed atomically when amount, account, or type changes. ' +
+      'categoryId is supported for all transaction types including transfers; pass null to clear it.',
     inputSchema: UpdateTransactionSchema.shape,
     annotations: { idempotentHint: false, destructiveHint: false },
     callback: updateTransactionTool,

--- a/packages/mcp-server/src/finances/tools/transactions.ts
+++ b/packages/mcp-server/src/finances/tools/transactions.ts
@@ -83,7 +83,15 @@ const TransactionItemSchema = z
       .regex(/^\d{4}-\d{2}-\d{2}$/)
       .optional(),
     toAccountId: z.number().int().positive().optional(),
-    categoryId: z.number().int().positive().optional(),
+    categoryId: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .describe(
+        'Optional category ID for this transaction. Supported for all transaction types including transfers. ' +
+          'Use finances_list_context to find available category IDs.',
+      ),
     payeeName: z.string().min(1).optional(),
     notes: z.string().min(1),
     labels: z.array(z.string().min(1)).optional(),
@@ -362,7 +370,16 @@ export const UpdateTransactionSchema = z.object({
     .optional(),
   accountId: z.number().int().positive().optional(),
   toAccountId: z.number().int().positive().optional(),
-  categoryId: z.number().int().positive().optional(),
+  categoryId: z
+    .number()
+    .int()
+    .positive()
+    .nullable()
+    .optional()
+    .describe(
+      'Category to assign. Supported for all transaction types including transfers. ' +
+        'Pass null to explicitly clear an existing category.',
+    ),
   payeeName: z.string().min(1).optional(),
   notes: z.string().min(1).optional(),
   labels: z.array(z.string().min(1)).optional(),


### PR DESCRIPTION
Transfer type now renders both a "To Account" picker and a "Category"
picker. Category is optional (clearable) for transfers, matching the
existing behaviour for income transactions. This lets users tag loan
repayments and other transfers with a spending category without
making it mandatory.

https://claude.ai/code/session_01Ds6m1WH9oRxhcG3FKkBhjJ