### PR TITLE
fix: include toAccountName in account and dashboard transaction responses

### DIFF
--- a/packages/hub/src/app/api/finances/accounts/[id]/route.ts
+++ b/packages/hub/src/app/api/finances/accounts/[id]/route.ts
@@ -31,6 +31,7 @@ export const accountTransactionSchema = z.object({
   balanceAfter: z.number().nullable(),
   isCorrection: z.boolean(),
   accountName: z.string(),
+  toAccountName: z.string().nullable(),
   addedByInitials: z.string().nullable(),
 });
 
@@ -116,6 +117,7 @@ export const GET = route({
     balanceAfter: t.accountId === accountId ? t.fromAccountBalanceAfter : t.toAccountBalanceAfter,
     isCorrection: t.isCorrection,
     accountName: t.accountName,
+    toAccountName: t.toAccountName,
     addedByInitials: t.addedByInitials,
   }));
 

--- a/packages/hub/src/app/api/finances/dashboard/route.ts
+++ b/packages/hub/src/app/api/finances/dashboard/route.ts
@@ -46,6 +46,7 @@ export const dashboardTransactionSchema = z.object({
   categoryColor: categoryColorSchema,
   categoryIcon: categoryIconSchema,
   accountName: z.string(),
+  toAccountName: z.string().nullable(),
   addedByInitials: z.string().nullable(),
 });
 


### PR DESCRIPTION
The accounts/[id] route schema and mapping, and the dashboard route schema,
were both missing the toAccountName field. This caused transfer transactions
to show '—' instead of 'Account A ↔ Account B' in the accounts detail page
and the finance dashboard recent transactions list.

https://claude.ai/code/session_01LdJp7GSobjhThoaWr9Z3cR