### PR TITLE
fix(hub): fix date picker resetting to today in transaction modal

### DIFF
--- a/packages/hub/src/app/finances/transactions/TransactionModal.tsx
+++ b/packages/hub/src/app/finances/transactions/TransactionModal.tsx
@@ -17,7 +17,7 @@ import type { PayeesResponse, PayeeWithSuggestion } from '@/app/api/finances/pay
 import type { TransactionFormDataResponse } from '@/app/api/finances/transactions/form-data/route';
 import type { TransactionDetail, TransactionMutationResponse } from '@/app/api/finances/transactions/[id]/route';
 import type { LabelsResponse } from '@/app/api/finances/labels/route';
-import { getCurrencySymbol, isPayeeRequired } from '@my-hub/shared/utils';
+import { getCurrencySymbol, isPayeeRequired, localDateString } from '@my-hub/shared/utils';
 import { EXPENSE_ACCOUNT_TYPES, TransactionType, TransactionTypes } from '@my-hub/shared/constants';
 import { TYPE_META } from '../ui';
 
@@ -151,7 +151,11 @@ export function TransactionModal({
     formState: { isSubmitting },
   } = useForm<AddTransactionValues>({
     resolver: zodResolver(AddTransactionSchema),
-    defaultValues: { ...defaultAddTransactionValues, txType: initialType ?? TransactionTypes.Expense },
+    defaultValues: {
+      ...defaultAddTransactionValues,
+      txType: initialType ?? TransactionTypes.Expense,
+      date: localDateString(),
+    },
   });
 
   useEffect(() => {
@@ -489,6 +493,7 @@ export function TransactionModal({
           <MobileFieldRow label="Date">
             <Input
               {...register('date')}
+              value={watch('date')}
               type="date"
               variant="ghost"
               className="flex-1 text-[13px] text-[var(--fin-text)]"
@@ -671,6 +676,7 @@ export function TransactionModal({
               <FieldCard label="Date">
                 <Input
                   {...register('date')}
+                  value={watch('date')}
                   type="date"
                   variant="ghost"
                   className="w-full text-[13px] text-[var(--fin-text)]"


### PR DESCRIPTION
The modal renders date inputs for both mobile and desktop layouts
simultaneously. React Hook Form's register() only tracks a single DOM
ref per field name; the desktop input (rendered second) wonpts, so
setValue('date', ...) only updated the hidden desktop input while the
mobile input stayed stuck on today (the defaultValues value).

Fixed by adding value={watch('date')} to both inputs, making them
controlled by the shared form state so setValue propagates to both.

Also changed the default date from a module-level UTC-based constant
(new Date().toISOString().slice(0,10)) to localDateString() computed
fresh on each modal mount, which correctly uses the browser's local
timezone.

https://claude.ai/code/session_014qRqU7JWxhpb3uTtzQdnjn