### PR TITLE
fix: number keypad commits on outside click and lets fields receive focus

### DIFF
--- a/packages/hub/src/app/finances/payees/MergePayeeModal.tsx
+++ b/packages/hub/src/app/finances/payees/MergePayeeModal.tsx
@@ -19,9 +19,7 @@ export function MergePayeeModal({ payee, allPayees, onClose, onMerged }: MergePa
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const options: DropdownOption[] = allPayees
-    .filter(p => p.id !== payee.id)
-    .map(p => ({ id: p.id, value: p.name }));
+  const options: DropdownOption[] = allPayees.filter(p => p.id !== payee.id).map(p => ({ id: p.id, value: p.name }));
 
   async function handleSubmit() {
     if (!sourceId) return;

--- a/packages/hub/src/app/finances/transactions/TransactionModal.tsx
+++ b/packages/hub/src/app/finances/transactions/TransactionModal.tsx
@@ -708,12 +708,8 @@ export function TransactionModal({
       {/* Keypad overlay — portalled bottom sheet on mobile */}
       {keypadOpen &&
         createPortal(
-          <div
-            className="finances-theme fixed inset-x-0 top-0 z-[1100] flex h-[100dvh] flex-col justify-end md:hidden pointer-events-none"
-          >
-            <div
-              className="fin-slide-up rounded-t-[18px] border border-[var(--fin-border)] bg-[var(--fin-card)] pointer-events-auto"
-            >
+          <div className="finances-theme fixed inset-x-0 top-0 z-[1100] flex h-[100dvh] flex-col justify-end md:hidden pointer-events-none">
+            <div className="fin-slide-up rounded-t-[18px] border border-[var(--fin-border)] bg-[var(--fin-card)] pointer-events-auto">
               <MobileAmountKeypad
                 onKey={pressKey}
                 onDone={() => {

--- a/packages/hub/src/app/finances/transactions/TransactionModal.tsx
+++ b/packages/hub/src/app/finances/transactions/TransactionModal.tsx
@@ -389,20 +389,7 @@ export function TransactionModal({
               {mobileAmountText}
             </span>
           )}
-          {amountDisplay || largeExpression ? (
-            <Button
-              type="button"
-              variant="transparent"
-              size="xs"
-              onClick={e => {
-                e.stopPropagation();
-                pressKey('Clear');
-              }}
-              className="mt-2 flex items-center gap-1 rounded-full border border-[var(--fin-border)] px-2.5 py-0.5 text-xs text-[var(--fin-muted)] active:opacity-60"
-            >
-              × Clear
-            </Button>
-          ) : !keypadOpen ? (
+          {!amountDisplay && !largeExpression && !keypadOpen ? (
             <span className="mt-1.5 text-xs text-[var(--fin-muted)]">Tap to Enter Amount</span>
           ) : null}
         </div>
@@ -410,7 +397,10 @@ export function TransactionModal({
         {/* Fields — scrollable */}
         <div
           className="flex-1 divide-y divide-[var(--fin-border)] overflow-y-auto border-t border-[var(--fin-border)]"
-          onClickCapture={() => setKeypadOpen(false)}
+          onClickCapture={() => {
+            pressKey('=');
+            setKeypadOpen(false);
+          }}
         >
           {payeeRequired && (
             <>
@@ -719,12 +709,10 @@ export function TransactionModal({
       {keypadOpen &&
         createPortal(
           <div
-            className="finances-theme fixed inset-x-0 top-0 z-[1100] flex h-[100dvh] flex-col justify-end md:hidden"
-            onClick={cancelKeypad}
+            className="finances-theme fixed inset-x-0 top-0 z-[1100] flex h-[100dvh] flex-col justify-end md:hidden pointer-events-none"
           >
             <div
-              className="fin-slide-up rounded-t-[18px] border border-[var(--fin-border)] bg-[var(--fin-card)]"
-              onClick={e => e.stopPropagation()}
+              className="fin-slide-up rounded-t-[18px] border border-[var(--fin-border)] bg-[var(--fin-card)] pointer-events-auto"
             >
               <MobileAmountKeypad
                 onKey={pressKey}


### PR DESCRIPTION
- Make keypad portal backdrop pointer-events-none so tapping a field
  behind it actually focuses that field instead of being swallowed
- Give the keypad card pointer-events-auto so it remains interactive
- Replace the cancelKeypad backdrop onClick (which reverted the typed
  amount) — closing via outside tap now commits the current value;
  onClickCapture on the fields div also evaluates any pending expression
- Remove the redundant "× Clear" label below the amount display