### PR TITLE
Show categorized transfer transactions in category views and dashboard

### DIFF
--- a/packages/hub/src/app/api/finances/categories/route.ts
+++ b/packages/hub/src/app/api/finances/categories/route.ts
@@ -21,6 +21,7 @@ export const categoryRowSchema = z.object({
   notes: z.string().nullable(),
   monthlyTarget: z.number().nullable(),
   spent: z.number(),
+  transferAmount: z.number(),
   groupId: z.number().int().nullable(),
   sortOrder: z.number().int(),
 });
@@ -39,6 +40,7 @@ export const categoriesResponseSchema = z.object({
   groups: z.array(categoryGroupSchema),
   ungrouped: z.array(categoryRowSchema),
   totalSpent: z.number(),
+  totalTransfers: z.number(),
   allCategories: z.array(categoryRowSchema),
 });
 
@@ -91,16 +93,24 @@ export const GET = route({ query: CategoryQuerySchema, response: categoriesRespo
   const lastDay = new Date(year!, mon!, 0).getDate();
   const toDate = `${month}-${String(lastDay).padStart(2, '0')}`;
 
-  const [groups, categories, expenseTxns] = await Promise.all([
+  const [groups, categories, expenseTxns, transferTxns] = await Promise.all([
     getGroups(user.id, budgetId),
     getCategories(user.id, budgetId),
     getTransactions(user.id, budgetId, { type: TransactionTypes.Expense, fromDate, toDate, limit: 2000 }),
+    getTransactions(user.id, budgetId, { type: TransactionTypes.Transfer, fromDate, toDate, limit: 2000 }),
   ]);
 
   const spentByCategory = new Map<number, number>();
   for (const t of expenseTxns) {
     if (t.categoryId != null) {
       spentByCategory.set(t.categoryId, (spentByCategory.get(t.categoryId) ?? 0) + t.amount);
+    }
+  }
+
+  const transferByCategory = new Map<number, number>();
+  for (const t of transferTxns) {
+    if (t.categoryId != null) {
+      transferByCategory.set(t.categoryId, (transferByCategory.get(t.categoryId) ?? 0) + t.amount);
     }
   }
 
@@ -112,6 +122,7 @@ export const GET = route({ query: CategoryQuerySchema, response: categoriesRespo
     notes: c.notes ?? null,
     monthlyTarget: c.monthlyTarget ?? null,
     spent: spentByCategory.get(c.id) ?? 0,
+    transferAmount: transferByCategory.get(c.id) ?? 0,
     groupId: c.groupId ?? null,
     sortOrder: c.sortOrder,
   }));
@@ -126,6 +137,7 @@ export const GET = route({ query: CategoryQuerySchema, response: categoriesRespo
 
   const ungrouped = catRows.filter(c => c.groupId === null);
   const totalSpent = catRows.reduce((s, c) => s + c.spent, 0);
+  const totalTransfers = catRows.reduce((s, c) => s + c.transferAmount, 0);
 
   return {
     currency: budget.defaultCurrency,
@@ -133,6 +145,7 @@ export const GET = route({ query: CategoryQuerySchema, response: categoriesRespo
     groups: groupRows,
     ungrouped,
     totalSpent,
+    totalTransfers,
     allCategories: catRows,
   };
 });

--- a/packages/hub/src/app/api/finances/categories/route.ts
+++ b/packages/hub/src/app/api/finances/categories/route.ts
@@ -136,8 +136,12 @@ export const GET = route({ query: CategoryQuerySchema, response: categoriesRespo
   }));
 
   const ungrouped = catRows.filter(c => c.groupId === null);
-  const totalSpent = catRows.reduce((s, c) => s + c.spent, 0);
-  const totalTransfers = catRows.reduce((s, c) => s + c.transferAmount, 0);
+  let totalSpent = 0;
+  let totalTransfers = 0;
+  for (const c of catRows) {
+    totalSpent += c.spent;
+    totalTransfers += c.transferAmount;
+  }
 
   return {
     currency: budget.defaultCurrency,

--- a/packages/hub/src/app/api/finances/dashboard/route.ts
+++ b/packages/hub/src/app/api/finances/dashboard/route.ts
@@ -65,6 +65,7 @@ export const financeDashboardDataSchema = z.object({
   availableBalance: z.number(),
   monthlyIncome: z.number(),
   monthlyExpense: z.number(),
+  monthlyTransfers: z.number(),
   categories: z.array(dashboardCategorySchema),
   dailySpending: z.array(dailySpendingPointSchema),
   goals: z.array(dashboardGoalSchema),
@@ -116,7 +117,7 @@ export const GET = route({ response: dashboardResponseSchema })(async ({ user })
   const prevMonthLastDay = new Date(now.getFullYear(), now.getMonth(), 0).getDate();
   const prevMonthEnd = `${prevYear}-${String(prevMonth).padStart(2, '0')}-${String(prevMonthLastDay).padStart(2, '0')}`;
 
-  const [accounts, categories, expenseTxns, incomeTxns, recentTxns, availableBalance, prevExpenseTxns] =
+  const [accounts, categories, expenseTxns, incomeTxns, transferTxns, recentTxns, availableBalance, prevExpenseTxns] =
     await Promise.all([
       getAccounts(user.id, budgetId),
       getCategories(user.id, budgetId),
@@ -128,6 +129,12 @@ export const GET = route({ response: dashboardResponseSchema })(async ({ user })
       }),
       getTransactions(user.id, budgetId, {
         type: TransactionTypes.Income,
+        fromDate: monthStart,
+        toDate: today,
+        limit: 2000,
+      }),
+      getTransactions(user.id, budgetId, {
+        type: TransactionTypes.Transfer,
         fromDate: monthStart,
         toDate: today,
         limit: 2000,
@@ -145,6 +152,7 @@ export const GET = route({ response: dashboardResponseSchema })(async ({ user })
   // Monthly totals
   const monthlyExpense = expenseTxns.reduce((sum, t) => sum + t.amount, 0);
   const monthlyIncome = incomeTxns.reduce((sum, t) => sum + t.amount, 0);
+  const monthlyTransfers = transferTxns.filter(t => t.categoryId != null).reduce((sum, t) => sum + t.amount, 0);
 
   // Single pass: category totals + daily map for current month
   const spentByCategory = new Map<number, number>();
@@ -218,6 +226,7 @@ export const GET = route({ response: dashboardResponseSchema })(async ({ user })
     availableBalance,
     monthlyIncome,
     monthlyExpense,
+    monthlyTransfers,
     categories: categorySpending,
     dailySpending,
     goals,

--- a/packages/hub/src/app/api/finances/dashboard/route.ts
+++ b/packages/hub/src/app/api/finances/dashboard/route.ts
@@ -152,7 +152,7 @@ export const GET = route({ response: dashboardResponseSchema })(async ({ user })
   // Monthly totals
   const monthlyExpense = expenseTxns.reduce((sum, t) => sum + t.amount, 0);
   const monthlyIncome = incomeTxns.reduce((sum, t) => sum + t.amount, 0);
-  const monthlyTransfers = transferTxns.filter(t => t.categoryId != null).reduce((sum, t) => sum + t.amount, 0);
+  const monthlyTransfers = transferTxns.reduce((sum, t) => (t.categoryId != null ? sum + t.amount : sum), 0);
 
   // Single pass: category totals + daily map for current month
   const spentByCategory = new Map<number, number>();

--- a/packages/hub/src/app/finances/DashboardScreen.tsx
+++ b/packages/hub/src/app/finances/DashboardScreen.tsx
@@ -25,7 +25,16 @@ type DashboardScreenProps = {
 
 export function DashboardScreen({ data, userName }: DashboardScreenProps) {
   const router = useRouter();
-  const { currency, availableBalance, monthlyIncome, monthlyExpense, categories, dailySpending, goals } = data;
+  const {
+    currency,
+    availableBalance,
+    monthlyIncome,
+    monthlyExpense,
+    monthlyTransfers,
+    categories,
+    dailySpending,
+    goals,
+  } = data;
 
   const saved = monthlyIncome - monthlyExpense;
 
@@ -62,6 +71,12 @@ export function DashboardScreen({ data, userName }: DashboardScreenProps) {
               <span className="text-[10px] text-[var(--fin-muted)]">Expenses</span>
               <span className="text-sm font-semibold text-[var(--fin-red)]">{fmt(monthlyExpense, currency)}</span>
             </div>
+            {monthlyTransfers > 0 && (
+              <div className="flex items-center justify-between">
+                <span className="text-[10px] text-[var(--fin-muted)]">Loan repayments</span>
+                <span className="text-sm font-semibold text-[var(--fin-red)]">{fmt(monthlyTransfers, currency)}</span>
+              </div>
+            )}
             <Divider />
             <div className="flex items-center justify-between">
               <span className="text-[10px] text-[var(--fin-muted)]">Saved</span>

--- a/packages/hub/src/app/finances/categories/CatRow.tsx
+++ b/packages/hub/src/app/finances/categories/CatRow.tsx
@@ -60,6 +60,11 @@ function CatRowContent({ cat, currency, onClick }: { cat: CategoryRow; currency:
       {pct !== null && (
         <Bar value={cat.spent} max={cat.monthlyTarget!} color={cat.color ?? 'var(--fin-green)'} height={4} />
       )}
+      {cat.transferAmount > 0 && (
+        <div className="mt-1 text-[10px] text-[var(--fin-subtle)]">
+          + {fmt(cat.transferAmount, currency)} repayments
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/hub/src/app/finances/categories/[id]/page.tsx
+++ b/packages/hub/src/app/finances/categories/[id]/page.tsx
@@ -104,6 +104,14 @@ export default function CategoryDetailPage() {
             </div>
           </div>
         </div>
+        {category.transferAmount > 0 && (
+          <div className="mt-2 rounded-lg border border-[var(--fin-border)] bg-[var(--fin-card2)] p-2.5">
+            <div className="text-[10px] uppercase tracking-[0.08em] text-[var(--fin-subtle)]">Loan repayments</div>
+            <div className="text-[16px] font-semibold text-[var(--fin-text)]">
+              {fmt(category.transferAmount, currency)}
+            </div>
+          </div>
+        )}
         {progress !== null && (
           <div className="mt-2 text-[11px] text-[var(--fin-subtle)]">
             Progress: <span className="font-semibold text-[var(--fin-text)]">{progress}%</span>

--- a/packages/hub/src/app/finances/categories/page.tsx
+++ b/packages/hub/src/app/finances/categories/page.tsx
@@ -111,6 +111,14 @@ export default function CategoriesPage() {
                   {fmt(data.totalSpent, data.currency)}
                 </span>
               </div>
+              {data.totalTransfers > 0 && (
+                <div className="mb-2 flex justify-between">
+                  <span className="text-[13px] text-[var(--fin-muted)]">Loan repayments</span>
+                  <span className="text-base font-bold text-[var(--fin-text)]">
+                    {fmt(data.totalTransfers, data.currency)}
+                  </span>
+                </div>
+              )}
               {data.totalSpent > 0 && (
                 <>
                   <div className="flex h-2 gap-px overflow-hidden rounded">


### PR DESCRIPTION
Transfers with an assigned category (e.g. loan repayments) were silently
excluded from all category pages and totals, making the category field
a write-only no-op for transfer transactions.

- Categories API: fetch categorized transfers alongside expenses; expose
  `transferAmount` per category and `totalTransfers` in response
- Dashboard API: fetch current-month categorized transfers; add
  `monthlyTransfers` to the response schema
- DashboardScreen: add "Loan repayments" line in the "This Month" card
  (only shown when > 0)
- Categories list page: add "Loan repayments" subtotal in the summary card
- CatRow: show a subtle "+ X repayments" line per category when > 0
- Category detail page: add a "Loan repayments" stat box (full-width,
  below Spent/Target) when the category has categorized transfers

Spending totals (budget progress, "Saved") remain expenses-only — loan
repayments reduce a liability and are not true expenses.

https://claude.ai/code/session_01Hat9z9HYEjYmKkAJiPd7qL