### PR TITLE
Add 'All time' payee filter and persist selected range in URL

### DIFF
--- a/packages/hub/src/app/api/finances/payees/report/route.ts
+++ b/packages/hub/src/app/api/finances/payees/report/route.ts
@@ -24,7 +24,7 @@ export const payeesReportResponseSchema = z.object({
 export type PayeeReportItem = z.infer<typeof payeeReportItemSchema>;
 export type PayeesReportResponse = z.infer<typeof payeesReportResponseSchema>;
 
-function getFromDate(range: string): string {
+function getFromDate(range: string): string | undefined {
   const now = new Date();
   if (range === '3m') {
     const d = new Date(now);
@@ -32,6 +32,7 @@ function getFromDate(range: string): string {
     return d.toISOString().slice(0, 10);
   }
   if (range === 'ytd') return `${now.getFullYear()}-01-01`;
+  if (range === 'all') return undefined;
   // default: 30d
   const d = new Date(now);
   d.setDate(d.getDate() - 30);
@@ -39,7 +40,7 @@ function getFromDate(range: string): string {
 }
 
 export const GET = route({
-  query: z.object({ range: z.enum(['30d', '3m', 'ytd']).default('30d') }),
+  query: z.object({ range: z.enum(['30d', '3m', 'ytd', 'all']).default('30d') }),
   response: payeesReportResponseSchema,
 })(async ({ user, query }) => {
   const { range } = query;

--- a/packages/hub/src/app/finances/payees/page.tsx
+++ b/packages/hub/src/app/finances/payees/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { apiFetch } from '@/lib/utils';
 import type { PayeesResponse, PayeeWithSuggestion } from '@/app/api/finances/payees/route';
 import type { PayeesReportResponse, PayeeReportItem } from '@/app/api/finances/payees/report/route';
@@ -14,8 +15,26 @@ import { PAYEE_RANGES, type Range, type SortKey } from './types';
 import { Input } from '@/components';
 import Fuse from 'fuse.js';
 
+const VALID_RANGES = new Set<Range>(['30d', '3m', 'ytd', 'all']);
+
+function parseRange(value: string | null): Range {
+  if (value && VALID_RANGES.has(value as Range)) return value as Range;
+  return '30d';
+}
+
 export default function PayeesPage() {
-  const [range, setRange] = useState<Range>('30d');
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const range = parseRange(searchParams.get('range'));
+
+  const setRange = useCallback(
+    (r: Range) => {
+      const params = new URLSearchParams(searchParams.toString());
+      params.set('range', r);
+      router.replace(`?${params.toString()}`, { scroll: false });
+    },
+    [router, searchParams],
+  );
   const [sortBy, setSortBy] = useState<SortKey>('totalSpent');
   const [search, setSearch] = useState('');
   const [reportData, setReportData] = useState<PayeesReportResponse | null>(null);

--- a/packages/hub/src/app/finances/payees/page.tsx
+++ b/packages/hub/src/app/finances/payees/page.tsx
@@ -12,15 +12,9 @@ import { PayeesRangeFilter } from './PayeesRangeFilter';
 import { PayeesTableHeader } from './PayeesTableHeader';
 import { PayeeRow } from './PayeeRow';
 import { PAYEE_RANGES, type Range, type SortKey } from './types';
+import { parseRange } from './payees.utils';
 import { Input } from '@/components';
 import Fuse from 'fuse.js';
-
-const VALID_RANGES = new Set<Range>(['30d', '3m', 'ytd', 'all']);
-
-function parseRange(value: string | null): Range {
-  if (value && VALID_RANGES.has(value as Range)) return value as Range;
-  return '30d';
-}
 
 export default function PayeesPage() {
   const router = useRouter();

--- a/packages/hub/src/app/finances/payees/payees.utils.ts
+++ b/packages/hub/src/app/finances/payees/payees.utils.ts
@@ -1,0 +1,8 @@
+import { PAYEE_RANGES, type Range } from './types';
+
+const VALID_RANGES = new Set(PAYEE_RANGES.map(r => r.key));
+
+export function parseRange(value: string | null): Range {
+  if (value && VALID_RANGES.has(value as Range)) return value as Range;
+  return '30d';
+}

--- a/packages/hub/src/app/finances/payees/types.ts
+++ b/packages/hub/src/app/finances/payees/types.ts
@@ -1,8 +1,9 @@
-export type Range = '30d' | '3m' | 'ytd';
+export type Range = '30d' | '3m' | 'ytd' | 'all';
 export type SortKey = 'totalSpent' | 'txCount' | 'name';
 
 export const PAYEE_RANGES: { key: Range; label: string }[] = [
   { key: '30d', label: 'Last 30 days' },
   { key: '3m', label: 'Last 3 months' },
   { key: 'ytd', label: 'This year' },
+  { key: 'all', label: 'All time' },
 ];


### PR DESCRIPTION
- Add 'all' to Range type and PAYEE_RANGES constant
- API route now accepts range=all and omits fromDate for unbounded query
- Page uses URL search param (?range=) instead of useState so the
  selected filter survives navigation to a payee detail and back

https://claude.ai/code/session_01RhRZ71gvr6drfpYyFoFj23