### PR TITLE
Show archived accounts in transaction edit dropdown

### DIFF
--- a/packages/hub/src/app/api/finances/transactions/form-data/route.ts
+++ b/packages/hub/src/app/api/finances/transactions/form-data/route.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { route, routeHttpError } from '@/lib/api/route';
-import { getUserActiveBudget, getAccounts, getAccountById, getCategories } from '@my-hub/shared/services';
+import { getUserActiveBudget, getAccounts, getCategories } from '@my-hub/shared/services';
 import { AccountTypes } from '@my-hub/shared/constants';
 import { supportedCurrencySchema } from '../../currency.schema';
 import { categoryIconSchema, categoryColorSchema } from '../../shared.schema';
@@ -29,39 +29,20 @@ export const transactionFormDataResponseSchema = z.object({
 
 export type TransactionFormDataResponse = z.infer<typeof transactionFormDataResponseSchema>;
 
-const formDataQuerySchema = z.object({
-  accountId: z.coerce.number().int().positive().optional(),
-  toAccountId: z.coerce.number().int().positive().optional(),
-});
-
-export const GET = route({ query: formDataQuerySchema, response: transactionFormDataResponseSchema })(async ({
-  user,
-  query,
-}) => {
+export const GET = route({ response: transactionFormDataResponseSchema })(async ({ user }) => {
   const budget = await getUserActiveBudget(user.id);
   if (!budget) routeHttpError(404, { error: 'No budget found' });
 
   const budgetId = budget.id;
 
-  const [activeAccounts, categories] = await Promise.all([
-    getAccounts(user.id, budgetId),
+  const [accounts, categories] = await Promise.all([
+    getAccounts(user.id, budgetId, { includeArchived: true }),
     getCategories(user.id, budgetId),
   ]);
 
-  // When editing a transaction, include its archived account(s) even though they're no longer active
-  const activeIds = new Set(activeAccounts.map(a => a.id));
-  const extraIds = [query?.accountId, query?.toAccountId].filter(
-    (id): id is number => id != null && !activeIds.has(id),
-  );
-  const extraAccounts = (await Promise.all(extraIds.map(id => getAccountById(user.id, budgetId, id)))).filter(
-    (a): a is NonNullable<typeof a> => a != null,
-  );
-
-  const allAccounts = [...activeAccounts, ...extraAccounts];
-
   return {
     currency: budget.defaultCurrency,
-    accounts: allAccounts.map(a => ({
+    accounts: accounts.map(a => ({
       id: a.id,
       name: a.name,
       type: a.type,

--- a/packages/hub/src/app/api/finances/transactions/form-data/route.ts
+++ b/packages/hub/src/app/api/finances/transactions/form-data/route.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { route, routeHttpError } from '@/lib/api/route';
-import { getUserActiveBudget, getAccounts, getCategories } from '@my-hub/shared/services';
+import { getUserActiveBudget, getAccounts, getAccountById, getCategories } from '@my-hub/shared/services';
 import { AccountTypes } from '@my-hub/shared/constants';
 import { supportedCurrencySchema } from '../../currency.schema';
 import { categoryIconSchema, categoryColorSchema } from '../../shared.schema';
@@ -10,6 +10,7 @@ export const transactionFormAccountSchema = z.object({
   name: z.string(),
   type: z.enum(AccountTypes),
   currency: supportedCurrencySchema,
+  archived: z.boolean(),
 });
 
 export const transactionFormCategorySchema = z.object({
@@ -28,17 +29,45 @@ export const transactionFormDataResponseSchema = z.object({
 
 export type TransactionFormDataResponse = z.infer<typeof transactionFormDataResponseSchema>;
 
-export const GET = route({ response: transactionFormDataResponseSchema })(async ({ user }) => {
+const formDataQuerySchema = z.object({
+  accountId: z.coerce.number().int().positive().optional(),
+  toAccountId: z.coerce.number().int().positive().optional(),
+});
+
+export const GET = route({ query: formDataQuerySchema, response: transactionFormDataResponseSchema })(async ({
+  user,
+  query,
+}) => {
   const budget = await getUserActiveBudget(user.id);
   if (!budget) routeHttpError(404, { error: 'No budget found' });
 
   const budgetId = budget.id;
 
-  const [accounts, categories] = await Promise.all([getAccounts(user.id, budgetId), getCategories(user.id, budgetId)]);
+  const [activeAccounts, categories] = await Promise.all([
+    getAccounts(user.id, budgetId),
+    getCategories(user.id, budgetId),
+  ]);
+
+  // When editing a transaction, include its archived account(s) even though they're no longer active
+  const activeIds = new Set(activeAccounts.map(a => a.id));
+  const extraIds = [query?.accountId, query?.toAccountId].filter(
+    (id): id is number => id != null && !activeIds.has(id),
+  );
+  const extraAccounts = (await Promise.all(extraIds.map(id => getAccountById(user.id, budgetId, id)))).filter(
+    (a): a is NonNullable<typeof a> => a != null,
+  );
+
+  const allAccounts = [...activeAccounts, ...extraAccounts];
 
   return {
     currency: budget.defaultCurrency,
-    accounts: accounts.map(a => ({ id: a.id, name: a.name, type: a.type, currency: a.currency })),
+    accounts: allAccounts.map(a => ({
+      id: a.id,
+      name: a.name,
+      type: a.type,
+      currency: a.currency,
+      archived: a.archived,
+    })),
     categories: categories.map(c => ({
       id: c.id,
       name: c.name,

--- a/packages/hub/src/app/finances/transactions/TransactionModal.tsx
+++ b/packages/hub/src/app/finances/transactions/TransactionModal.tsx
@@ -140,41 +140,36 @@ export function TransactionModal({
   const payeeRequired = isPayeeRequired(txType);
 
   const load = useCallback(async () => {
-    // In edit mode, fetch the transaction first so we know which archived accounts to include in form-data
-    const detail = isEdit
-      ? await apiFetch<TransactionDetail>(`/api/finances/transactions/${editId}`, { silentToast: true })
-      : null;
-
-    const [fd, pd, labelsData] = await Promise.all([
-      apiFetch<TransactionFormDataResponse>('/api/finances/transactions/form-data', {
-        silentToast: true,
-        query: detail ? { accountId: detail.accountId, toAccountId: detail.toAccountId ?? undefined } : undefined,
-      }),
+    const [fd, pd, labelsData, selectedTransaction] = await Promise.all([
+      apiFetch<TransactionFormDataResponse>('/api/finances/transactions/form-data', { silentToast: true }),
       apiFetch<PayeesResponse>('/api/finances/payees', { silentToast: true }),
       apiFetch<LabelsResponse>('/api/finances/labels', { silentToast: true }),
+      isEdit
+        ? apiFetch<TransactionDetail>(`/api/finances/transactions/${editId}`, { silentToast: true })
+        : Promise.resolve(null),
     ]);
 
     setFormData(fd);
     if (pd) setPayees(pd.payees);
     if (labelsData) setAllLabels(labelsData.labels);
 
-    if (detail) {
-      setValue('txType', detail.type);
-      setFromAmount(String(detail.amount));
-      setValue('date', detail.date);
-      setValue('payee', detail.payeeName ?? '');
-      setValue('note', detail.notes ?? '');
-      setValue('labels', detail.labels ?? []);
-      setSelPayeeId(detail.payeeId ?? null);
+    if (selectedTransaction) {
+      setValue('txType', selectedTransaction.type);
+      setFromAmount(String(selectedTransaction.amount));
+      setValue('date', selectedTransaction.date);
+      setValue('payee', selectedTransaction.payeeName ?? '');
+      setValue('note', selectedTransaction.notes ?? '');
+      setValue('labels', selectedTransaction.labels ?? []);
+      setSelPayeeId(selectedTransaction.payeeId ?? null);
 
-      setSelAccId(detail.accountId);
+      setSelAccId(selectedTransaction.accountId);
 
-      if (detail.toAccountId != null) {
-        setSelToAccId(detail.toAccountId);
+      if (selectedTransaction.toAccountId != null) {
+        setSelToAccId(selectedTransaction.toAccountId);
       }
 
-      if (detail.categoryId != null) {
-        setSelCatId(detail.categoryId);
+      if (selectedTransaction.categoryId != null) {
+        setSelCatId(selectedTransaction.categoryId);
       }
     }
   }, [editId, isEdit, setValue, setFromAmount]);
@@ -275,18 +270,16 @@ export function TransactionModal({
     [expressionTerms],
   );
 
-  const accountOptions = useMemo(() => {
-    const base =
-      txType === TransactionTypes.Expense
+  const accountOptions = useMemo(
+    () =>
+      (txType === TransactionTypes.Expense
         ? (formData?.accounts ?? []).filter(a => EXPENSE_ACCOUNT_TYPES.has(a.type as never))
-        : (formData?.accounts ?? []);
-    const active = base.filter(a => !a.archived);
-    const archived = base.filter(a => a.archived);
-    return [
-      ...active.map(a => ({ id: a.id, value: a.name })),
-      ...archived.map(a => ({ id: a.id, value: `${a.name} (archived)` })),
-    ];
-  }, [txType, formData?.accounts]);
+        : (formData?.accounts ?? [])
+      )
+        .filter(a => !a.archived || a.id === selAccId) // filter archived transactions except if already selected
+        .map(a => ({ id: a.id, value: a.name })),
+    [txType, formData?.accounts, selAccId],
+  );
 
   const categoryOptions = useMemo(
     () =>
@@ -297,15 +290,14 @@ export function TransactionModal({
     [formData?.categories],
   );
 
-  const toAccountOptions = useMemo(() => {
-    const base = (formData?.accounts ?? []).filter(a => a.id !== selAccId);
-    const active = base.filter(a => !a.archived);
-    const archived = base.filter(a => a.archived);
-    return [
-      ...active.map(a => ({ id: a.id, value: a.name })),
-      ...archived.map(a => ({ id: a.id, value: `${a.name} (archived)` })),
-    ];
-  }, [formData?.accounts, selAccId]);
+  const toAccountOptions = useMemo(
+    () =>
+      (formData?.accounts ?? [])
+        .filter(a => a.id !== selAccId)
+        .filter(a => !a.archived || a.id === selToAccId) // filter archived transactions except if already selected
+        .map(a => ({ id: a.id, value: a.name })),
+    [formData?.accounts, selAccId, selToAccId],
+  );
 
   const payeeOptions = useMemo(
     () => [...payees.map(p => ({ id: p.id, value: p.name })), ...extraPayees.map(p => ({ id: p.id, value: p.name }))],

--- a/packages/hub/src/app/finances/transactions/TransactionModal.tsx
+++ b/packages/hub/src/app/finances/transactions/TransactionModal.tsx
@@ -140,13 +140,18 @@ export function TransactionModal({
   const payeeRequired = isPayeeRequired(txType);
 
   const load = useCallback(async () => {
-    const [fd, pd, labelsData, detail] = await Promise.all([
-      apiFetch<TransactionFormDataResponse>('/api/finances/transactions/form-data', { silentToast: true }),
+    // In edit mode, fetch the transaction first so we know which archived accounts to include in form-data
+    const detail = isEdit
+      ? await apiFetch<TransactionDetail>(`/api/finances/transactions/${editId}`, { silentToast: true })
+      : null;
+
+    const [fd, pd, labelsData] = await Promise.all([
+      apiFetch<TransactionFormDataResponse>('/api/finances/transactions/form-data', {
+        silentToast: true,
+        query: detail ? { accountId: detail.accountId, toAccountId: detail.toAccountId ?? undefined } : undefined,
+      }),
       apiFetch<PayeesResponse>('/api/finances/payees', { silentToast: true }),
       apiFetch<LabelsResponse>('/api/finances/labels', { silentToast: true }),
-      isEdit
-        ? apiFetch<TransactionDetail>(`/api/finances/transactions/${editId}`, { silentToast: true })
-        : Promise.resolve(null),
     ]);
 
     setFormData(fd);
@@ -270,14 +275,18 @@ export function TransactionModal({
     [expressionTerms],
   );
 
-  const accountOptions = useMemo(
-    () =>
-      (txType === TransactionTypes.Expense
+  const accountOptions = useMemo(() => {
+    const base =
+      txType === TransactionTypes.Expense
         ? (formData?.accounts ?? []).filter(a => EXPENSE_ACCOUNT_TYPES.has(a.type as never))
-        : (formData?.accounts ?? [])
-      ).map(a => ({ id: a.id, value: a.name })),
-    [txType, formData?.accounts],
-  );
+        : (formData?.accounts ?? []);
+    const active = base.filter(a => !a.archived);
+    const archived = base.filter(a => a.archived);
+    return [
+      ...active.map(a => ({ id: a.id, value: a.name })),
+      ...archived.map(a => ({ id: a.id, value: `${a.name} (archived)` })),
+    ];
+  }, [txType, formData?.accounts]);
 
   const categoryOptions = useMemo(
     () =>
@@ -288,10 +297,15 @@ export function TransactionModal({
     [formData?.categories],
   );
 
-  const toAccountOptions = useMemo(
-    () => (formData?.accounts ?? []).filter(a => a.id !== selAccId).map(a => ({ id: a.id, value: a.name })),
-    [formData?.accounts, selAccId],
-  );
+  const toAccountOptions = useMemo(() => {
+    const base = (formData?.accounts ?? []).filter(a => a.id !== selAccId);
+    const active = base.filter(a => !a.archived);
+    const archived = base.filter(a => a.archived);
+    return [
+      ...active.map(a => ({ id: a.id, value: a.name })),
+      ...archived.map(a => ({ id: a.id, value: `${a.name} (archived)` })),
+    ];
+  }, [formData?.accounts, selAccId]);
 
   const payeeOptions = useMemo(
     () => [...payees.map(p => ({ id: p.id, value: p.name })), ...extraPayees.map(p => ({ id: p.id, value: p.name }))],

--- a/packages/hub/src/app/finances/ui.tsx
+++ b/packages/hub/src/app/finances/ui.tsx
@@ -309,7 +309,10 @@ export function AddButton({ onClick, title }: AddButtonProps) {
 
 // ─── Dropdown option renderers ───────────────────────────────────────────────
 
-export function renderAccountOption(item: DropdownOption, accounts: { id: number; type: string; currency: string }[]) {
+export function renderAccountOption(
+  item: DropdownOption,
+  accounts: { id: number; type: string; currency: string; archived?: boolean }[],
+) {
   const acc = accounts.find(a => String(a.id) === String(item.id));
   const meta = acc ? (TYPE_META[acc.type] ?? null) : null;
   return (
@@ -322,7 +325,12 @@ export function renderAccountOption(item: DropdownOption, accounts: { id: number
           {meta.icon}
         </span>
       )}
-      <span className="flex-1 truncate">{String(item.value)}</span>
+      <span className={cn('flex-1 truncate', acc?.archived && 'text-[var(--fin-subtle)]')}>{String(item.value)}</span>
+      {acc?.archived && (
+        <span className="shrink-0 rounded bg-[var(--fin-card3)] px-1 text-[9px] uppercase tracking-wide text-[var(--fin-subtle)]">
+          archived
+        </span>
+      )}
       {acc && <span className="ml-auto shrink-0 text-[10px] text-[var(--fin-subtle)]">{acc.currency}</span>}
     </span>
   );


### PR DESCRIPTION
When editing a transaction whose account has since been archived, the
account is now included in the form-data response and shown in the
dropdown as the selected value with an "(archived)" label and muted
styling. Active accounts appear first in the list; the archived account
appears at the end so the user can see the current selection but is
guided toward active accounts when changing.

https://claude.ai/code/session_01S1ce7b9GTtztrCprmJRyjA