### PR TITLE
Add month selection to finance dashboard

### DIFF
--- a/packages/hub/src/app/api/finances/dashboard/route.ts
+++ b/packages/hub/src/app/api/finances/dashboard/route.ts
@@ -4,6 +4,7 @@ import {
   getAccounts,
   getCategories,
   getTransactions,
+  getTransactionListItems,
   getAvailableBalance,
   getUserActiveBudget,
   getUserBudgets,
@@ -68,6 +69,7 @@ export const financeDashboardDataSchema = z.object({
   categories: z.array(dashboardCategorySchema),
   dailySpending: z.array(dailySpendingPointSchema),
   goals: z.array(dashboardGoalSchema),
+  recentTransactions: z.array(dashboardTransactionSchema),
 });
 
 export const noBudgetResponseSchema = z.object({
@@ -141,6 +143,7 @@ export const GET = route({ query: DashboardQuerySchema, response: dashboardRespo
     expenseTxns,
     incomeTxns,
     transferTxns,
+    recentTxns,
     availableBalance,
     prevExpenseTxns,
     prevTransferTxns,
@@ -165,6 +168,7 @@ export const GET = route({ query: DashboardQuerySchema, response: dashboardRespo
       toDate,
       limit: 2000,
     }),
+    getTransactionListItems(user.id, budgetId, { limit: 5 }),
     getAvailableBalance(user.id, budgetId),
     getTransactions(user.id, budgetId, {
       type: TransactionTypes.Expense,
@@ -272,6 +276,7 @@ export const GET = route({ query: DashboardQuerySchema, response: dashboardRespo
     categories: categorySpending,
     dailySpending,
     goals,
+    recentTransactions: recentTxns,
   };
 
   return data;

--- a/packages/hub/src/app/api/finances/dashboard/route.ts
+++ b/packages/hub/src/app/api/finances/dashboard/route.ts
@@ -4,7 +4,6 @@ import {
   getAccounts,
   getCategories,
   getTransactions,
-  getTransactionListItems,
   getAvailableBalance,
   getUserActiveBudget,
   getUserBudgets,
@@ -69,7 +68,6 @@ export const financeDashboardDataSchema = z.object({
   categories: z.array(dashboardCategorySchema),
   dailySpending: z.array(dailySpendingPointSchema),
   goals: z.array(dashboardGoalSchema),
-  recentTransactions: z.array(dashboardTransactionSchema),
 });
 
 export const noBudgetResponseSchema = z.object({
@@ -91,7 +89,7 @@ export type DashboardResponse = z.infer<typeof dashboardResponseSchema>;
 const DashboardQuerySchema = z.object({
   month: z
     .string()
-    .regex(/^\d{4}-\d{2}$/, 'month must be YYYY-MM')
+    .regex(/^\d{4}-(0[1-9]|1[0-2])$/, 'month must be YYYY-MM')
     .optional(),
 });
 
@@ -126,8 +124,9 @@ export const GET = route({ query: DashboardQuerySchema, response: dashboardRespo
   const monthLastDay = new Date(selYear, selMon, 0).getDate();
   const monthEnd = `${selectedMonth}-${String(monthLastDay).padStart(2, '0')}`;
   const today = now.toISOString().slice(0, 10);
+  const isFutureMonth = selectedMonth > currentYearMonth;
   const toDate = isCurrentMonth ? today : monthEnd;
-  const todayDay = isCurrentMonth ? now.getDate() : monthLastDay;
+  const todayDay = isCurrentMonth ? now.getDate() : isFutureMonth ? 0 : monthLastDay;
 
   const prevMonthDate = new Date(selYear, selMon - 2, 1);
   const prevYear = prevMonthDate.getFullYear();
@@ -142,7 +141,6 @@ export const GET = route({ query: DashboardQuerySchema, response: dashboardRespo
     expenseTxns,
     incomeTxns,
     transferTxns,
-    recentTxns,
     availableBalance,
     prevExpenseTxns,
     prevTransferTxns,
@@ -167,7 +165,6 @@ export const GET = route({ query: DashboardQuerySchema, response: dashboardRespo
       toDate,
       limit: 2000,
     }),
-    getTransactionListItems(user.id, budgetId, { limit: 5 }),
     getAvailableBalance(user.id, budgetId),
     getTransactions(user.id, budgetId, {
       type: TransactionTypes.Expense,
@@ -275,7 +272,6 @@ export const GET = route({ query: DashboardQuerySchema, response: dashboardRespo
     categories: categorySpending,
     dailySpending,
     goals,
-    recentTransactions: recentTxns,
   };
 
   return data;

--- a/packages/hub/src/app/api/finances/dashboard/route.ts
+++ b/packages/hub/src/app/api/finances/dashboard/route.ts
@@ -88,7 +88,17 @@ export type FinanceDashboardData = z.infer<typeof financeDashboardDataSchema>;
 export type NoBudgetResponse = z.infer<typeof noBudgetResponseSchema>;
 export type DashboardResponse = z.infer<typeof dashboardResponseSchema>;
 
-export const GET = route({ response: dashboardResponseSchema })(async ({ user }) => {
+const DashboardQuerySchema = z.object({
+  month: z
+    .string()
+    .regex(/^\d{4}-\d{2}$/, 'month must be YYYY-MM')
+    .optional(),
+});
+
+export const GET = route({ query: DashboardQuerySchema, response: dashboardResponseSchema })(async ({
+  user,
+  query,
+}) => {
   const budget = await getUserActiveBudget(user.id);
   if (!budget) {
     const allBudgets = await getUserBudgets(user.id);
@@ -107,14 +117,23 @@ export const GET = route({ response: dashboardResponseSchema })(async ({ user })
   const currency = budget.defaultCurrency;
 
   const now = new Date();
-  const monthStart = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-01`;
-  const today = now.toISOString().slice(0, 10);
+  const currentYearMonth = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
+  const selectedMonth = query.month ?? currentYearMonth;
+  const [selYear, selMon] = selectedMonth.split('-').map(Number) as [number, number];
+  const isCurrentMonth = selectedMonth === currentYearMonth;
 
-  const prevMonthDate = new Date(now.getFullYear(), now.getMonth() - 1, 1);
+  const monthStart = `${selectedMonth}-01`;
+  const monthLastDay = new Date(selYear, selMon, 0).getDate();
+  const monthEnd = `${selectedMonth}-${String(monthLastDay).padStart(2, '0')}`;
+  const today = now.toISOString().slice(0, 10);
+  const toDate = isCurrentMonth ? today : monthEnd;
+  const todayDay = isCurrentMonth ? now.getDate() : monthLastDay;
+
+  const prevMonthDate = new Date(selYear, selMon - 2, 1);
   const prevYear = prevMonthDate.getFullYear();
   const prevMonth = prevMonthDate.getMonth() + 1;
   const prevMonthStart = `${prevYear}-${String(prevMonth).padStart(2, '0')}-01`;
-  const prevMonthLastDay = new Date(now.getFullYear(), now.getMonth(), 0).getDate();
+  const prevMonthLastDay = new Date(selYear, selMon - 1, 0).getDate();
   const prevMonthEnd = `${prevYear}-${String(prevMonth).padStart(2, '0')}-${String(prevMonthLastDay).padStart(2, '0')}`;
 
   const [
@@ -133,19 +152,19 @@ export const GET = route({ response: dashboardResponseSchema })(async ({ user })
     getTransactions(user.id, budgetId, {
       type: TransactionTypes.Expense,
       fromDate: monthStart,
-      toDate: today,
+      toDate,
       limit: 2000,
     }),
     getTransactions(user.id, budgetId, {
       type: TransactionTypes.Income,
       fromDate: monthStart,
-      toDate: today,
+      toDate,
       limit: 2000,
     }),
     getTransactions(user.id, budgetId, {
       type: TransactionTypes.Transfer,
       fromDate: monthStart,
-      toDate: today,
+      toDate,
       limit: 2000,
     }),
     getTransactionListItems(user.id, budgetId, { limit: 5 }),
@@ -219,12 +238,10 @@ export const GET = route({ response: dashboardResponseSchema })(async ({ user })
     categorySpending.push({ id: -1, name: 'Other', icon: null, color: null, spent: uncategorized });
   }
 
-  const todayDay = now.getDate();
-  const currentMonthLastDay = new Date(now.getFullYear(), now.getMonth() + 1, 0).getDate();
   const dailySpending: { day: number; current: number | null; prev: number }[] = [];
   let currentCumulative = 0;
   let prevCumulative = 0;
-  for (let d = 1; d <= currentMonthLastDay; d++) {
+  for (let d = 1; d <= monthLastDay; d++) {
     if (d <= todayDay) {
       currentCumulative += currentDayMap.get(d) ?? 0;
     }

--- a/packages/hub/src/app/finances/DashboardCharts.tsx
+++ b/packages/hub/src/app/finances/DashboardCharts.tsx
@@ -126,9 +126,11 @@ export function CategoryPieChart({ categories, currency }: CategoryPieChartProps
 type SpendingTrendChartProps = {
   dailySpending: DailySpendingPoint[];
   currency: SupportedCurrency;
+  monthLabel?: string;
+  prevLabel?: string;
 };
 
-export function SpendingTrendChart({ dailySpending, currency }: SpendingTrendChartProps) {
+export function SpendingTrendChart({ dailySpending, currency, monthLabel, prevLabel }: SpendingTrendChartProps) {
   if (dailySpending.length === 0) return null;
 
   return (
@@ -149,7 +151,7 @@ export function SpendingTrendChart({ dailySpending, currency }: SpendingTrendCha
                 <div style={{ color: 'var(--fin-muted)', fontSize: 10, marginBottom: 4 }}>Day {label}</div>
                 {payload.map((p, i) => (
                   <div key={i} style={{ color: p.color as string, marginBottom: 2 }}>
-                    {p.name === 'current' ? 'This month' : 'Prev month'}:{' '}
+                    {p.name === 'current' ? (monthLabel ?? 'This month') : (prevLabel ?? 'Prev month')}:{' '}
                     {typeof p.value === 'number' ? fmt(p.value, currency) : String(p.value)}
                   </div>
                 ))}

--- a/packages/hub/src/app/finances/DashboardScreen.tsx
+++ b/packages/hub/src/app/finances/DashboardScreen.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter } from 'next/navigation';
 import { cn } from '@/lib/utils';
+import { formatMonthStr, shiftMonthStr } from '@my-hub/shared/utils';
 import { fmt, Card, SectionLabel, Bar, Divider, SubText, MonthCarousel } from './ui';
 import { CategoryPieChart, SpendingTrendChart } from './DashboardCharts';
 import { TransactionList } from './transactions/TransactionList';
@@ -45,7 +46,12 @@ export function DashboardScreen({ data, userName, selectedMonth, currentMonth, o
           {getGreeting()}
           {userName ? `, ${userName}` : ''}
         </div>
-        <MonthCarousel month={selectedMonth} onNavigate={onMonthChange} currentMonth={currentMonth} />
+        <MonthCarousel
+          month={selectedMonth}
+          onNavigate={onMonthChange}
+          currentMonth={currentMonth}
+          maxMonth={currentMonth}
+        />
       </div>
 
       {/* Available balance + cashflow row */}
@@ -58,7 +64,9 @@ export function DashboardScreen({ data, userName, selectedMonth, currentMonth, o
         </Card>
 
         <Card className="p-[14px]">
-          <SubText className="block mb-1.5 uppercase tracking-[0.08em]">This Month</SubText>
+          <SubText className="block mb-1.5 uppercase tracking-[0.08em]">
+            {selectedMonth === currentMonth ? 'This Month' : formatMonthStr(selectedMonth)}
+          </SubText>
           <div className="mt-1 flex flex-col gap-1.5">
             <div className="flex items-center justify-between">
               <span className="text-[10px] text-[var(--fin-muted)]">Income</span>
@@ -111,16 +119,21 @@ export function DashboardScreen({ data, userName, selectedMonth, currentMonth, o
                 <div className="flex items-center gap-2 text-[9px] text-[var(--fin-muted)]">
                   <span className="flex items-center gap-1">
                     <span className="inline-block h-[2px] w-4 bg-[var(--fin-accent)]" />
-                    This month
+                    {selectedMonth === currentMonth ? 'This month' : formatMonthStr(selectedMonth)}
                   </span>
                   <span className="flex items-center gap-1">
                     <span className="inline-block h-[2px] w-4 border-t border-dashed border-[var(--fin-subtle)]" />
-                    Prev
+                    {formatMonthStr(shiftMonthStr(selectedMonth, -1))}
                   </span>
                 </div>
               </div>
               <div className="h-[200px]">
-                <SpendingTrendChart dailySpending={dailySpending} currency={currency} />
+                <SpendingTrendChart
+                  dailySpending={dailySpending}
+                  currency={currency}
+                  monthLabel={selectedMonth === currentMonth ? 'This month' : formatMonthStr(selectedMonth)}
+                  prevLabel={formatMonthStr(shiftMonthStr(selectedMonth, -1))}
+                />
               </div>
             </Card>
           )}
@@ -168,7 +181,7 @@ export function DashboardScreen({ data, userName, selectedMonth, currentMonth, o
           </span>
         </div>
 
-        <TransactionList limit={5} />
+        <TransactionList limit={5} month={selectedMonth} />
       </Card>
     </div>
   );

--- a/packages/hub/src/app/finances/DashboardScreen.tsx
+++ b/packages/hub/src/app/finances/DashboardScreen.tsx
@@ -2,7 +2,7 @@
 
 import { useRouter } from 'next/navigation';
 import { cn } from '@/lib/utils';
-import { fmt, Card, SectionLabel, Bar, Divider, SubText } from './ui';
+import { fmt, Card, SectionLabel, Bar, Divider, SubText, MonthCarousel } from './ui';
 import { CategoryPieChart, SpendingTrendChart } from './DashboardCharts';
 import { TransactionList } from './transactions/TransactionList';
 import type { FinanceDashboardData } from '@/app/api/finances/dashboard/route';
@@ -14,16 +14,15 @@ function getGreeting() {
   return 'Good evening';
 }
 
-function currentMonthLabel() {
-  return new Date().toLocaleDateString('en-IE', { month: 'long', year: 'numeric' });
-}
-
 type DashboardScreenProps = {
   data: FinanceDashboardData;
   userName?: string;
+  selectedMonth: string;
+  currentMonth: string;
+  onMonthChange: (month: string) => void;
 };
 
-export function DashboardScreen({ data, userName }: DashboardScreenProps) {
+export function DashboardScreen({ data, userName, selectedMonth, currentMonth, onMonthChange }: DashboardScreenProps) {
   const router = useRouter();
   const {
     currency,
@@ -41,14 +40,12 @@ export function DashboardScreen({ data, userName }: DashboardScreenProps) {
   return (
     <div className="flex flex-col gap-[14px]">
       {/* Header */}
-      <div className="flex items-start justify-between">
-        <div>
-          <div className="mb-0.5 text-xs text-[var(--fin-subtle)]">
-            {getGreeting()}
-            {userName ? `, ${userName}` : ''}
-          </div>
-          <div className="text-[22px] font-bold tracking-[-0.02em] text-[var(--fin-text)]">{currentMonthLabel()}</div>
+      <div>
+        <div className="mb-1 text-xs text-[var(--fin-subtle)]">
+          {getGreeting()}
+          {userName ? `, ${userName}` : ''}
         </div>
+        <MonthCarousel month={selectedMonth} onNavigate={onMonthChange} currentMonth={currentMonth} />
       </div>
 
       {/* Available balance + cashflow row */}

--- a/packages/hub/src/app/finances/categories/CatRow.tsx
+++ b/packages/hub/src/app/finances/categories/CatRow.tsx
@@ -18,10 +18,7 @@ type CatRowProps = {
 };
 
 function CatRowContent({ cat, currency, onClick }: { cat: CategoryRow; currency: string; onClick?: () => void }) {
-  const pct =
-    cat.monthlyTarget && cat.monthlyTarget > 0
-      ? Math.min(100, Math.round((cat.spent / cat.monthlyTarget) * 100))
-      : null;
+  const pct = cat.monthlyTarget && cat.monthlyTarget > 0 ? Math.round((cat.spent / cat.monthlyTarget) * 100) : null;
   const barColor =
     pct === null
       ? 'var(--fin-muted)'

--- a/packages/hub/src/app/finances/categories/page.tsx
+++ b/packages/hub/src/app/finances/categories/page.tsx
@@ -125,15 +125,20 @@ export default function CategoriesPage() {
                     })}
                   </div>
                   <div className="mt-2 flex flex-wrap gap-2.5">
-                    {spentCategories.map(cat => (
-                      <div key={cat.id} className="flex items-center gap-1">
-                        <div
-                          className="rounded-sm"
-                          style={{ width: 7, height: 7, background: cat.color ?? 'var(--fin-muted)' }}
-                        />
-                        <span className="text-[10px] text-[var(--fin-muted)]">{cat.name}</span>
-                      </div>
-                    ))}
+                    {spentCategories.map(cat => {
+                      const pct = Math.round((cat.spent / data.totalSpent) * 100);
+                      return (
+                        <div key={cat.id} className="flex items-center gap-1">
+                          <div
+                            className="rounded-sm"
+                            style={{ width: 7, height: 7, background: cat.color ?? 'var(--fin-muted)' }}
+                          />
+                          <span className="text-[10px] text-[var(--fin-muted)]">
+                            {cat.name} <span className="text-[var(--fin-subtle)]">{pct}%</span>
+                          </span>
+                        </div>
+                      );
+                    })}
                   </div>
                 </>
               )}

--- a/packages/hub/src/app/finances/page.tsx
+++ b/packages/hub/src/app/finances/page.tsx
@@ -3,25 +3,29 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useSession } from 'next-auth/react';
 import { apiFetch } from '@/lib/utils';
+import { dateToString } from '@my-hub/shared/utils';
 import { DashboardScreen } from './DashboardScreen';
 import { CreateBudgetScreen } from './CreateBudgetScreen';
 import { BudgetSelectorScreen } from './BudgetSelectorScreen';
 import type { DashboardResponse, FinanceDashboardData, NoBudgetResponse } from '@/app/api/finances/dashboard/route';
+
+const CURRENT_MONTH = dateToString(new Date(), 'YYYY-MM');
 
 export default function FinancesPage() {
   const { data: session } = useSession();
   const [response, setResponse] = useState<DashboardResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [showCreate, setShowCreate] = useState(false);
+  const [selectedMonth, setSelectedMonth] = useState(CURRENT_MONTH);
   // Tracks the latest load invocation so stale responses (e.g. from React Strict
   // Mode's second effect run) do not overwrite a fresher result.
   const loadIdRef = useRef(0);
 
-  const load = useCallback(async () => {
+  const load = useCallback(async (month: string) => {
     const loadId = ++loadIdRef.current;
     setLoading(true);
     try {
-      const result = await apiFetch<DashboardResponse>('/api/finances/dashboard', {
+      const result = await apiFetch<DashboardResponse>(`/api/finances/dashboard?month=${month}`, {
         silentToast: true,
       });
       if (loadId !== loadIdRef.current) return;
@@ -32,8 +36,8 @@ export default function FinancesPage() {
   }, []);
 
   useEffect(() => {
-    load();
-  }, [load]);
+    load(selectedMonth);
+  }, [selectedMonth, load]);
 
   if (loading) {
     return (
@@ -64,7 +68,7 @@ export default function FinancesPage() {
           budgets={available}
           onActivated={() => {
             setShowCreate(false);
-            void load();
+            void load(selectedMonth);
           }}
           onCreateNew={() => setShowCreate(true)}
         />
@@ -75,7 +79,7 @@ export default function FinancesPage() {
       <CreateBudgetScreen
         onCreated={() => {
           setShowCreate(false);
-          void load();
+          void load(selectedMonth);
         }}
       />
     );
@@ -84,5 +88,13 @@ export default function FinancesPage() {
   const data = response as FinanceDashboardData;
   const firstName = session?.user?.name?.split(' ')[0];
 
-  return <DashboardScreen data={data} userName={firstName} />;
+  return (
+    <DashboardScreen
+      data={data}
+      userName={firstName}
+      selectedMonth={selectedMonth}
+      currentMonth={CURRENT_MONTH}
+      onMonthChange={setSelectedMonth}
+    />
+  );
 }

--- a/packages/hub/src/app/finances/ui.tsx
+++ b/packages/hub/src/app/finances/ui.tsx
@@ -364,11 +364,20 @@ type MonthCarouselProps = {
   onNavigate: (m: string) => void;
   /** When provided, shows a "Today" pill next to the carousel whenever `month` differs from `currentMonth`. */
   currentMonth?: string;
+  /** When provided, the forward chevron is disabled once `month` reaches this value. */
+  maxMonth?: string;
   className?: string;
   labelClassName?: string;
 };
 
-export function MonthCarousel({ month, onNavigate, currentMonth, className, labelClassName }: MonthCarouselProps) {
+export function MonthCarousel({
+  month,
+  onNavigate,
+  currentMonth,
+  maxMonth,
+  className,
+  labelClassName,
+}: MonthCarouselProps) {
   return (
     <div className={cn('flex items-center gap-3', className)}>
       <IconButton
@@ -386,7 +395,8 @@ export function MonthCarousel({ month, onNavigate, currentMonth, className, labe
         label="Next month"
         icon={<ChevronRightOutlineIcon />}
         onClick={() => onNavigate(shiftMonthStr(month, 1))}
-        className="bg-transparent text-[var(--fin-muted)] hover:bg-transparent hover:text-[var(--fin-text)]"
+        disabled={maxMonth !== undefined && month >= maxMonth}
+        className="bg-transparent text-[var(--fin-muted)] hover:bg-transparent hover:text-[var(--fin-text)] disabled:opacity-30"
       />
       {currentMonth !== undefined && month !== currentMonth && (
         <Button variant="fin-pill" size="xs" onClick={() => onNavigate(currentMonth)}>

--- a/packages/hub/src/components/IconButton.tsx
+++ b/packages/hub/src/components/IconButton.tsx
@@ -9,6 +9,7 @@ interface Props {
   onClick?: () => void;
   href?: string;
   loading?: boolean;
+  disabled?: boolean;
   className?: string;
   variant?: 'default' | 'ghost';
 }
@@ -18,7 +19,16 @@ const variantClassName = {
   ghost: 'text-zinc-400 hover:text-zinc-200 transition-colors',
 };
 
-export function IconButton({ label, icon, onClick, href, loading = false, className, variant = 'default' }: Props) {
+export function IconButton({
+  label,
+  icon,
+  onClick,
+  href,
+  loading = false,
+  disabled = false,
+  className,
+  variant = 'default',
+}: Props) {
   const content = loading ? <SpinnerIcon className="opacity-70" /> : icon;
   const base = variantClassName[variant];
 
@@ -33,7 +43,7 @@ export function IconButton({ label, icon, onClick, href, loading = false, classN
   return (
     <button
       onClick={onClick}
-      disabled={loading}
+      disabled={loading || disabled}
       className={cn(base, 'disabled:opacity-50', className)}
       aria-label={label}
       title={label}


### PR DESCRIPTION
## Summary
Add the ability to view the finance dashboard for any month, not just the current month. Users can now navigate between months using a new month carousel component, and the dashboard data updates accordingly.

## Key Changes
- **API route** (`packages/hub/src/app/api/finances/dashboard/route.ts`):
  - Added `DashboardQuerySchema` to accept an optional `month` query parameter in `YYYY-MM` format
  - Updated date calculations to use the selected month instead of always using the current month
  - Adjusted transaction queries and daily spending calculations to respect the selected month's boundaries

- **Page component** (`packages/hub/src/app/finances/page.tsx`):
  - Added `selectedMonth` state to track the currently viewed month
  - Updated `load()` callback to accept and pass the selected month to the API
  - Pass `selectedMonth`, `currentMonth`, and `onMonthChange` props to `DashboardScreen`

- **Dashboard screen** (`packages/hub/src/app/finances/DashboardScreen.tsx`):
  - Replaced static month label with new `MonthCarousel` component for month navigation
  - Removed `currentMonthLabel()` helper function
  - Accept and wire up month selection props

- **Categories page** (`packages/hub/src/app/finances/categories/page.tsx`):
  - Display spending percentage for each category in the legend
  - Removed unnecessary `Math.min(100, ...)` clamping in `CatRow.tsx` to allow percentages over 100% when spending exceeds budget

## Implementation Details
- Month validation uses regex pattern `YYYY-MM` to ensure consistent formatting
- When viewing a past month, the dashboard uses the last day of that month instead of today's date for transaction queries
- Daily spending chart correctly handles different month lengths and displays data up to the selected month's end date
- Previous month calculations properly account for the selected month context

https://claude.ai/code/session_013sKr8DvHKL1vsWtnMX2NWx