### PR TITLE
Fix loan balance calculation to use amortization-derived principal

### DIFF
--- a/packages/hub/src/app/api/finances/accounts/[id]/route.ts
+++ b/packages/hub/src/app/api/finances/accounts/[id]/route.ts
@@ -110,7 +110,7 @@ export const GET = route({
     if (loanSnapshot) {
       account = {
         ...account,
-        balance: rawAccount.balance - loanSnapshot.amortizationSummary.totalInterestRemaining,
+        balance: loanSnapshot.balance,
         amortizationSummary: loanSnapshot.amortizationSummary,
       };
     }

--- a/packages/hub/src/app/api/finances/accounts/route.ts
+++ b/packages/hub/src/app/api/finances/accounts/route.ts
@@ -198,18 +198,17 @@ export const GET = route({ response: accountsListResponseSchema })(async ({ user
       const loanSnapshot = isLoan
         ? await getLoanBalanceSnapshotForAccount(user.id, budgetId, account, { accountCurrencyById })
         : null;
-      // For loans, display balance = -(remainingPrincipal + totalInterestRemaining), dynamically
-      // computed from actual payment history by the amortization service. This reflects the true
-      // total still owed and handles overpayments and floating rates correctly.
-      // Other liabilities (credit cards etc.) use account.balance directly.
-      const bal = loanSnapshot
-        ? account.balance - loanSnapshot.amortizationSummary.totalInterestRemaining
-        : account.balance;
+      // For loans, use the amortization-derived remaining principal (positive) as the display
+      // balance. This matches what the MCP context tool returns and correctly reflects how much
+      // principal still needs to be repaid, independent of the interest included in each payment.
+      const bal = loanSnapshot ? loanSnapshot.balance : account.balance;
       const isOtherLiability = !isLoan && LIABILITY_TYPES.has(account.type);
       const includedInAvailable = isIncludedInAvailable(account.type, prefs.get(account.id) ?? null);
       if (!account.archived) {
-        netWorth += isOtherLiability ? -bal : bal;
-        if (includedInAvailable) availableBalance += isOtherLiability ? -bal : bal;
+        // Loans: positive remaining principal must be subtracted from net worth (it's a liability).
+        // Other liabilities and assets keep the existing sign convention.
+        netWorth += isLoan || isOtherLiability ? -bal : bal;
+        if (includedInAvailable) availableBalance += isLoan || isOtherLiability ? -bal : bal;
       }
       return {
         id: account.id,

--- a/packages/hub/src/app/finances/accounts/AccountDetailView.tsx
+++ b/packages/hub/src/app/finances/accounts/AccountDetailView.tsx
@@ -258,6 +258,14 @@ function AccountHeader({ acc }: { acc: AccountItem }) {
             <SubText className="block">Monthly</SubText>
             <div className="text-[var(--fin-muted)]">{fmt(acc.amortizationSummary.monthlyPayment, acc.currency)}</div>
           </div>
+          {acc.amortizationSummary.totalInterestRemaining > 0 && (
+            <div>
+              <SubText className="block">Remaining interest</SubText>
+              <div className="text-[var(--fin-amber)]">
+                {fmt(acc.amortizationSummary.totalInterestRemaining, acc.currency)}
+              </div>
+            </div>
+          )}
           {acc.amortizationSummary.totalCost > 0 && (
             <div>
               <SubText className="block">Paid off</SubText>
@@ -265,7 +273,11 @@ function AccountHeader({ acc }: { acc: AccountItem }) {
                 {Math.max(
                   0,
                   Math.round(
-                    ((acc.amortizationSummary.totalCost + acc.balance) / acc.amortizationSummary.totalCost) * 100,
+                    ((acc.amortizationSummary.totalCost -
+                      acc.balance -
+                      acc.amortizationSummary.totalInterestRemaining) /
+                      acc.amortizationSummary.totalCost) *
+                      100,
                   ),
                 )}
                 %


### PR DESCRIPTION
## Summary
Corrects loan account balance display and net worth calculations to use the amortization service's computed remaining principal instead of deriving it from `account.balance - totalInterestRemaining`. This ensures consistency with the MCP context tool and correctly reflects the principal still owed.

## Changes

- **`packages/hub/src/app/api/finances/accounts/route.ts`**
  - Simplified loan balance calculation: use `loanSnapshot.balance` (amortization-derived remaining principal) directly instead of `account.balance - totalInterestRemaining`
  - Updated net worth and available balance logic to treat loans as liabilities (subtract from totals), matching other liability types
  - Clarified comments to explain that the amortization service computes the true remaining principal independent of interest

- **`packages/hub/src/app/api/finances/accounts/[id]/route.ts`**
  - Applied the same balance calculation fix: use `loanSnapshot.balance` instead of `account.balance - totalInterestRemaining`

- **`packages/hub/src/app/finances/accounts/AccountDetailView.tsx`**
  - Added conditional display of "Remaining interest" field when `totalInterestRemaining > 0`
  - Fixed "Paid off" percentage calculation to account for the new balance semantics:
    - Changed from `(totalCost + balance) / totalCost` to `(totalCost - balance - totalInterestRemaining) / totalCost`
    - This correctly computes progress as principal paid down, independent of interest

## Implementation Details
The amortization service already computes `loanSnapshot.balance` as the remaining principal. By using this directly instead of deriving it from account balance, we eliminate a calculation mismatch and ensure the Hub UI displays the same principal amount that the MCP context tool returns. Loans are now consistently treated as liabilities in net worth calculations.

https://claude.ai/code/session_01QZpMJruVBZCv1A5h4EB2wA