### PR TITLE
feat(travel): link trip places to day notes with map chips

### DIFF
--- a/docs/requirements/hub/feature-my-travels.md
+++ b/docs/requirements/hub/feature-my-travels.md
@@ -42,6 +42,7 @@ The My Travels page provides a clear, visual travel organizer in Hub where users
 | FR-24 | Itinerary Navigate actions should prioritize precise coordinates (`lat`/`lng`) and support common map input formats (Google share links, plus codes, `geo:` URIs, and coordinate strings). |
 | FR-27 | Navigate actions are endpoint-aware per chip: start segments route to origin/start location, end segments route to destination/end location (for example flight departure vs arrival).     |
 | FR-28 | Reservations can store an optional reference link (for example booking portal URLs), editable in Hub and exposed as an itinerary action in Coming Next.                                    |
+| FR-29 | Day notes support linked places (placeIds array). Day cards render linked places as amber map-chip badges; clicking a chip opens Google Maps at the place's coordinates or location text.  |
 | FR-25 | While trip overview data is loading, the right-side travel content should render structured skeleton placeholders to avoid abrupt section pop-in.                                          |
 | FR-26 | Trip map section is collapsible and defaults to collapsed; users can expand it on demand per selected trip.                                                                                |
 | FR-22 | When the travel page opens, it automatically selects the nearest upcoming trip (by start date); falls back to the first trip if none have a future start date.                             |
@@ -83,6 +84,7 @@ The My Travels page provides a clear, visual travel organizer in Hub where users
 | TR-28 | `coming-next-utils.ts` resolves Navigate action URLs by priority: valid booking `lat`/`lng`, then direct map links, then structured location strings (plus code, `geo:` URI, coordinate pair), then plain-text fallback query.                                                                      |
 | TR-31 | `coming-next-utils.ts` derives endpoint-specific Navigate actions (`start` vs `end`), using flight origin/destination IATA when present and directional location strings when available.                                                                                                            |
 | TR-32 | `trip_bookings` includes nullable `reference_link`; Hub booking POST/PATCH APIs persist it; `BookingsSection` add/edit forms expose it; `coming-next-utils.ts` emits an "Open link" action when present.                                                                                            |
+| TR-33 | `trip_days` gains `place_ids integer[]` column; `DayByDay.tsx` renders linked places as amber chips using `PinIcon` with `getPlaceMapUrl` (lat/lng preferred, falls back to location text then name).                                                                                               |
 | TR-29 | `TravelOverviewSkeleton` in `packages/hub/src/app/travel/TravelOverviewSkeleton.tsx` provides a placeholder layout shown when `loadingOverview` is true and no overview payload is yet available for the selected trip.                                                                             |
 | TR-30 | `packages/hub/src/app/travel/TripMap.tsx` owns map collapse/expand behavior (including header toggle UI) and resets to collapsed when its `tripId` prop changes.                                                                                                                                    |
 
@@ -132,5 +134,6 @@ The My Travels page provides a clear, visual travel organizer in Hub where users
 - [x] Travel page shows skeleton placeholders while selected-trip overview data is initially loading.
 - [x] Trip map is collapsible and starts collapsed for each selected trip.
 - [x] Travel page opens to the nearest upcoming trip automatically.
+- [x] Day cards show linked places as clickable amber map chips (opens Google Maps at coordinates or location text).
 - [x] Reservation rows expand on click to reveal full details (location, cost, notes, attachments).
 - [x] Flight booking form includes seat field in add and edit modes.

--- a/docs/requirements/mcps/feature-travel-management.md
+++ b/docs/requirements/mcps/feature-travel-management.md
@@ -16,15 +16,16 @@ Travel Management adds a Google Trips-inspired domain where users can organize t
 
 ## Functional Requirements
 
-| ID    | Requirement                                                                                                                                                                            |
-| ----- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| FR-01 | Users can create and manage trips containing reservations, places, checklist items, companions, and documents.                                                                         |
-| FR-02 | Reservations support multiple booking categories in one merged model (`trip_bookings`) using `bookingType` plus `details` JSONB.                                                       |
-| FR-03 | MCP exposes task-oriented travel tools (planning, importing reservations from text, preparing checklist, managing travel companions, generating trip brief, attaching document links). |
-| FR-04 | MCP exposes read-only resources for quick travel context snapshots.                                                                                                                    |
-| FR-05 | All travel data is scoped to the authenticated user.                                                                                                                                   |
-| FR-06 | Hub provides the primary full CRUD experience for detailed travel editing.                                                                                                             |
-| FR-07 | MCP travel booking tools should capture and persist a direct reservation reference link when one is available in user-provided context.                                                |
+| ID    | Requirement                                                                                                                                                                                                         |
+| ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| FR-01 | Users can create and manage trips containing reservations, places, checklist items, companions, and documents.                                                                                                      |
+| FR-02 | Reservations support multiple booking categories in one merged model (`trip_bookings`) using `bookingType` plus `details` JSONB.                                                                                    |
+| FR-03 | MCP exposes task-oriented travel tools (planning, importing reservations from text, preparing checklist, managing travel companions, generating trip brief, attaching document links).                              |
+| FR-04 | MCP exposes read-only resources for quick travel context snapshots.                                                                                                                                                 |
+| FR-05 | All travel data is scoped to the authenticated user.                                                                                                                                                                |
+| FR-06 | Hub provides the primary full CRUD experience for detailed travel editing.                                                                                                                                          |
+| FR-07 | MCP travel booking tools should capture and persist a direct reservation reference link when one is available in user-provided context.                                                                             |
+| FR-08 | Day notes support linked places (placeIds array). `travel_upsert_day_note` accepts `placeIds` and guides AI to provide precise location data. `travel_get_day_notes` returns days enriched with full place details. |
 
 ---
 
@@ -41,6 +42,7 @@ Travel Management adds a Google Trips-inspired domain where users can organize t
 | TR-07 | Document upload/linking uses server-backed storage volume with DB metadata in V1.                                                                                                                       |
 | TR-08 | Travel file constraints (`TRAVEL_FILES_MAX_MB`, `TRAVEL_FILES_ALLOWED_MIME`) are parsed centrally in app config and exposed via MCP resource.                                                           |
 | TR-09 | Travel booking MCP tools (`travel_add_reservation_from_text`, `travel_add_flight`, `travel_add_transport`, and edit tools) accept `reference_link` URL inputs and pass them to shared booking services. |
+| TR-10 | `trip_days.place_ids integer[]` column stores place associations. Migration generated from Drizzle schema; COALESCE in conflict update preserves associations when Hub UI saves without placeIds.       |
 
 ---
 
@@ -65,4 +67,5 @@ Travel Management adds a Google Trips-inspired domain where users can organize t
 - [x] MCP travel booking tools capture optional reservation reference links when available.
 - [x] Hub `/travel` polished UI implemented.
 - [x] Server file upload API + storage volume wiring implemented.
+- [x] Day notes linked to places via placeIds; MCP guides AI to use precise locations; Hub renders place chips with map links.
 - [ ] E2E coverage for travel flows implemented.

--- a/packages/hub/src/app/api/travel/trips/[id]/days/route.ts
+++ b/packages/hub/src/app/api/travel/trips/[id]/days/route.ts
@@ -5,6 +5,7 @@ const DayCreateSchema = z.object({
   date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'date is required (YYYY-MM-DD)'),
   title: z.string().nullable().optional(),
   notes: z.string().nullable().optional(),
+  placeIds: z.array(z.number().int()).nullable().optional(),
 });
 
 export const GET = route({ params: z.object({ id: z.coerce.number().int().positive() }) })(async ({ user, params }) => {
@@ -18,6 +19,7 @@ export const POST = route({ params: z.object({ id: z.coerce.number().int().posit
     const day = await upsertTripDay(user.id, tripId, body.date, {
       title: body.title ?? null,
       notes: body.notes ?? null,
+      placeIds: body.placeIds,
     });
     return { day };
   },

--- a/packages/hub/src/app/travel/DayByDay.tsx
+++ b/packages/hub/src/app/travel/DayByDay.tsx
@@ -3,15 +3,25 @@
 import { useState } from 'react';
 import { SectionCard } from '@/components/SectionCard';
 import { BookingTypeIcon, Button, Input, Textarea } from '@/components';
-import type { TripWithStatus } from '@my-hub/shared/types';
+import { PinIcon } from '@/components/icons';
+import type { TripPlace, TripWithStatus } from '@my-hub/shared/types';
 import type { TripBookingExtended, TripDay } from './types';
 import { calendarDays, formatDayHeading, toUTCDateStr } from '@my-hub/shared/utils';
 import { apiFetch } from '@/lib/utils';
+
+function getPlaceMapUrl(place: TripPlace): string {
+  if (place.lat != null && place.lng != null) {
+    return `https://www.google.com/maps?q=${place.lat},${place.lng}`;
+  }
+  const query = place.location ?? place.name;
+  return `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(query)}`;
+}
 
 type DayByDayProps = {
   trip: TripWithStatus;
   bookings: TripBookingExtended[];
   dayNotes: TripDay[];
+  places: TripPlace[];
   canEdit: boolean;
   onChanged: () => void;
 };
@@ -20,12 +30,13 @@ type DayCardProps = {
   dateStr: string;
   note: TripDay | undefined;
   bookings: TripBookingExtended[];
+  dayPlaces: TripPlace[];
   canEdit: boolean;
   onSaved: (date: string, title: string, notes: string) => Promise<void>;
   onDeleted: (id: number) => Promise<void>;
 };
 
-function DayCard({ dateStr, note, bookings, canEdit, onSaved, onDeleted }: DayCardProps) {
+function DayCard({ dateStr, note, bookings, dayPlaces, canEdit, onSaved, onDeleted }: DayCardProps) {
   const [editing, setEditing] = useState(false);
   const [title, setTitle] = useState(note?.title ?? '');
   const [notes, setNotes] = useState(note?.notes ?? '');
@@ -139,6 +150,23 @@ function DayCard({ dateStr, note, bookings, canEdit, onSaved, onDeleted }: DayCa
         <div className="space-y-1">
           {note.title && <p className="text-sm font-medium text-zinc-300">{note.title}</p>}
           {note.notes && <p className="text-xs text-zinc-400 whitespace-pre-wrap leading-relaxed">{note.notes}</p>}
+          {dayPlaces.length > 0 && (
+            <div className="flex flex-wrap gap-1 pt-1">
+              {dayPlaces.map(place => (
+                <a
+                  key={place.id}
+                  href={getPlaceMapUrl(place)}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  title={place.location ?? place.name}
+                  className="inline-flex min-w-0 max-w-full items-center gap-1 rounded-full border border-amber-700/60 bg-amber-950/30 py-0.5 px-2 text-xs text-amber-300 hover:bg-amber-900/40 hover:text-amber-200 transition-colors"
+                >
+                  <PinIcon />
+                  <span className="max-w-[10rem] truncate">{place.name}</span>
+                </a>
+              ))}
+            </div>
+          )}
         </div>
       ) : (
         dayBookings.length === 0 && <p className="text-xs italic text-zinc-600">No bookings or notes for this day.</p>
@@ -147,13 +175,14 @@ function DayCard({ dateStr, note, bookings, canEdit, onSaved, onDeleted }: DayCa
   );
 }
 
-export function DayByDay({ trip, bookings, dayNotes, canEdit, onChanged }: DayByDayProps) {
+export function DayByDay({ trip, bookings, dayNotes, places, canEdit, onChanged }: DayByDayProps) {
   if (!trip.startAt || !trip.endAt) return null;
 
   const days = calendarDays(new Date(trip.startAt), new Date(trip.endAt));
   if (days.length === 0) return null;
 
   const noteByDate = new Map<string, TripDay>(dayNotes.map(n => [n.date, n]));
+  const placesById = new Map<number, TripPlace>(places.map(p => [p.id, p]));
 
   async function handleSaved(tripId: number, date: string, title: string, notes: string) {
     await apiFetch(`/api/travel/trips/${tripId}/days`, {
@@ -171,17 +200,24 @@ export function DayByDay({ trip, bookings, dayNotes, canEdit, onChanged }: DayBy
   return (
     <SectionCard title="Day by Day" className="bg-zinc-950/40 border-zinc-800/60">
       <div className="space-y-3">
-        {days.map(dateStr => (
-          <DayCard
-            key={dateStr}
-            dateStr={dateStr}
-            note={noteByDate.get(dateStr)}
-            bookings={bookings}
-            canEdit={canEdit}
-            onSaved={(date, title, notes) => handleSaved(trip.id, date, title, notes)}
-            onDeleted={handleDeleted}
-          />
-        ))}
+        {days.map(dateStr => {
+          const note = noteByDate.get(dateStr);
+          const dayPlaces = (note?.placeIds ?? [])
+            .map(id => placesById.get(id))
+            .filter((p): p is TripPlace => p != null);
+          return (
+            <DayCard
+              key={dateStr}
+              dateStr={dateStr}
+              note={note}
+              bookings={bookings}
+              dayPlaces={dayPlaces}
+              canEdit={canEdit}
+              onSaved={(date, title, notes) => handleSaved(trip.id, date, title, notes)}
+              onDeleted={handleDeleted}
+            />
+          );
+        })}
       </div>
     </SectionCard>
   );

--- a/packages/hub/src/app/travel/DayByDay.tsx
+++ b/packages/hub/src/app/travel/DayByDay.tsx
@@ -10,10 +10,7 @@ import { calendarDays, formatDayHeading, toUTCDateStr } from '@my-hub/shared/uti
 import { apiFetch } from '@/lib/utils';
 
 function getPlaceMapUrl(place: TripPlace): string {
-  if (place.lat != null && place.lng != null) {
-    return `https://www.google.com/maps?q=${place.lat},${place.lng}`;
-  }
-  const query = place.location ?? place.name;
+  const query = place.lat != null && place.lng != null ? `${place.lat},${place.lng}` : (place.location ?? place.name);
   return `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(query)}`;
 }
 

--- a/packages/hub/src/app/travel/page.tsx
+++ b/packages/hub/src/app/travel/page.tsx
@@ -210,6 +210,7 @@ export default function TravelPage() {
                   trip={overview.trip}
                   bookings={overview.bookings}
                   dayNotes={overview.dayNotes}
+                  places={overview.places}
                   canEdit={canEditActiveTrip}
                   onChanged={handleOverviewChanged}
                 />

--- a/packages/mcp-server/e2e/travel.e2e.ts
+++ b/packages/mcp-server/e2e/travel.e2e.ts
@@ -147,14 +147,15 @@ describe.sequential('travel — trip and booking lifecycle', () => {
 
     const result = await client.callTool({
       name: 'travel_get_trip_brief',
-      arguments: { tripId },
+      arguments: { tripId, include: ['bookings'] },
     });
 
     expect(result.isError).toBeFalsy();
     const data = parseToolResult<TripBriefResult>(result);
 
     expect(data.trip.id).toBe(tripId);
-    expect(data.bookings.some(b => b.id === bookingId)).toBe(true);
+    expect(Array.isArray(data.bookings)).toBe(true);
+    expect(data.bookings.some((b: { id: number }) => b.id === bookingId)).toBe(true);
   });
 
   it('travel://trips resource includes the created trip', async () => {

--- a/packages/mcp-server/src/travel/tools/days.ts
+++ b/packages/mcp-server/src/travel/tools/days.ts
@@ -20,7 +20,7 @@ export const TravelUpsertDayNoteSchema = z.object({
     .optional()
     .describe(
       'Free-text notes for the day. Markdown is supported. ' +
-        'When referencing places in the notes, first ensure they exist as trip places (use travel_get_trip_brief to see existing places). ' +
+        'When referencing places in the notes, first ensure they exist as trip places (use travel_get_places to see existing places). ' +
         'Then pass their IDs via placeIds — this links them as interactive map chips in the UI.',
     ),
   placeIds: z
@@ -28,7 +28,7 @@ export const TravelUpsertDayNoteSchema = z.object({
     .optional()
     .describe(
       'IDs of trip places to associate with this day. ' +
-        'Obtain IDs from existing places returned by travel_get_trip_brief. ' +
+        'Obtain IDs from existing places returned by travel_get_places. ' +
         'If a place does not exist yet and the user mentions visiting a specific location, ' +
         'create it first (with precise coordinates or a full address) so it can be linked here. ' +
         'Location should be a specific street address, landmark name with city, or lat/lng coordinates — ' +

--- a/packages/mcp-server/src/travel/tools/days.ts
+++ b/packages/mcp-server/src/travel/tools/days.ts
@@ -1,7 +1,7 @@
 import { HandledError } from '../../shared/errors';
 import { ToolHandler } from '../../shared/types';
 import { z } from 'zod';
-import { deleteTripDay, getTripDays, upsertTripDay } from '@my-hub/shared/services';
+import { deleteTripDay, getTripDays, getTripPlaces, upsertTripDay } from '@my-hub/shared/services';
 import { toolResponse } from '../../shared/toolsUtils';
 
 // ---------------------------------------------------------------------------
@@ -15,7 +15,25 @@ export const TravelUpsertDayNoteSchema = z.object({
     .regex(/^\d{4}-\d{2}-\d{2}$/, 'Must be an ISO date string, e.g. "2026-06-21"')
     .describe('Calendar date for this day entry, e.g. "2026-06-21".'),
   title: z.string().optional().describe('Short label for the day, e.g. "Travel day" or "Day at the beach".'),
-  notes: z.string().optional().describe('Free-text notes for the day. Markdown is supported.'),
+  notes: z
+    .string()
+    .optional()
+    .describe(
+      'Free-text notes for the day. Markdown is supported. ' +
+        'When referencing places in the notes, first ensure they exist as trip places (use travel_get_trip_brief to see existing places). ' +
+        'Then pass their IDs via placeIds — this links them as interactive map chips in the UI.',
+    ),
+  placeIds: z
+    .array(z.number().int().positive())
+    .optional()
+    .describe(
+      'IDs of trip places to associate with this day. ' +
+        'Obtain IDs from existing places returned by travel_get_trip_brief. ' +
+        'If a place does not exist yet and the user mentions visiting a specific location, ' +
+        'create it first (with precise coordinates or a full address) so it can be linked here. ' +
+        'Location should be a specific street address, landmark name with city, or lat/lng coordinates — ' +
+        'not a vague description. Omit to preserve the current place associations.',
+    ),
 });
 
 export const travelUpsertDayNoteTool: ToolHandler<typeof TravelUpsertDayNoteSchema.shape> = async (input, context) => {
@@ -24,6 +42,7 @@ export const travelUpsertDayNoteTool: ToolHandler<typeof TravelUpsertDayNoteSche
   const day = await upsertTripDay(userId, input.tripId, input.date, {
     title: input.title ?? null,
     notes: input.notes ?? null,
+    placeIds: input.placeIds,
   });
 
   return toolResponse({ message: 'Day note saved.', day });
@@ -40,9 +59,16 @@ export const TravelGetDayNotesSchema = z.object({
 export const travelGetDayNotesTool: ToolHandler<typeof TravelGetDayNotesSchema.shape> = async (input, context) => {
   const { userId } = context;
 
-  const days = await getTripDays(userId, input.tripId);
+  const [days, places] = await Promise.all([getTripDays(userId, input.tripId), getTripPlaces(userId, input.tripId)]);
 
-  return toolResponse({ days });
+  const placesById = new Map(places.map(p => [p.id, p]));
+
+  const daysWithPlaces = days.map(day => ({
+    ...day,
+    places: (day.placeIds ?? []).map(id => placesById.get(id)).filter(Boolean),
+  }));
+
+  return toolResponse({ days: daysWithPlaces });
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/mcp-server/src/travel/tools/places.ts
+++ b/packages/mcp-server/src/travel/tools/places.ts
@@ -1,0 +1,104 @@
+import { ToolHandler } from '../../shared/types';
+import { z } from 'zod';
+import { addTripPlace, deleteTripPlace, getTripPlaces, updateTripPlace } from '@my-hub/shared/services';
+import { TripPlacePriorities, tripPlacePriorityValues } from '@my-hub/shared/constants';
+import type { TripPlacePriority } from '@my-hub/shared/types';
+import { omitUndefined } from '@my-hub/shared/utils';
+import { toolResponse } from '../../shared/toolsUtils';
+
+const PrioritySchema = z.enum(tripPlacePriorityValues as [TripPlacePriority, ...TripPlacePriority[]]);
+
+const locationGuidance =
+  'Provide a precise address or landmark with city, e.g. "Piazza del Colosseo 1, 00184 Rome, Italy". ' +
+  'If you have lat/lng, include those too — they produce a more accurate map pin.';
+
+const PlaceAddSchema = z.object({
+  name: z.string().trim().min(1).describe('Place name, e.g. "Colosseum" or "Hilton Roma Est".'),
+  location: z.string().optional().describe(`Full address or landmark description. ${locationGuidance}`),
+  notes: z.string().optional().describe('Optional notes about the place.'),
+  priority: PrioritySchema.optional().describe('Visit priority: low, medium (default), or high.'),
+  visited: z.boolean().optional().describe('Mark as already visited. Default false.'),
+  lat: z.number().optional().describe('Latitude in decimal degrees.'),
+  lng: z.number().optional().describe('Longitude in decimal degrees.'),
+});
+
+const PlaceUpdateSchema = PlaceAddSchema.partial().extend({
+  id: z.number().int().positive().describe('ID of the place to update.'),
+});
+
+// ---------------------------------------------------------------------------
+// travel_manage_places
+// ---------------------------------------------------------------------------
+
+export const TravelManagePlacesSchema = z.object({
+  tripId: z.number().int().positive().describe('Trip ID to manage places for.'),
+  add: z
+    .array(PlaceAddSchema)
+    .optional()
+    .describe(
+      `Places to add. ${locationGuidance} ` +
+        'After adding, the returned place IDs can be passed to travel_upsert_day_note to link places to days.',
+    ),
+  update: z
+    .array(PlaceUpdateSchema)
+    .optional()
+    .describe('Places to update (requires id). Only provided fields are changed; omitted fields are preserved.'),
+  removeIds: z
+    .array(z.number().int().positive())
+    .optional()
+    .describe('IDs of places to remove. Use when a location is no longer relevant.'),
+});
+
+export const travelManagePlacesTool: ToolHandler<typeof TravelManagePlacesSchema.shape> = async (input, context) => {
+  const { userId } = context;
+
+  for (const place of input.add ?? []) {
+    await addTripPlace(userId, input.tripId, {
+      name: place.name,
+      location: place.location ?? null,
+      notes: place.notes ?? null,
+      priority: place.priority ?? TripPlacePriorities.Medium,
+      visited: place.visited ?? false,
+      lat: place.lat ?? null,
+      lng: place.lng ?? null,
+    });
+  }
+
+  for (const place of input.update ?? []) {
+    await updateTripPlace(
+      userId,
+      place.id,
+      omitUndefined({
+        name: place.name,
+        location: place.location,
+        notes: place.notes,
+        priority: place.priority,
+        visited: place.visited,
+        lat: place.lat,
+        lng: place.lng,
+      }),
+    );
+  }
+
+  for (const placeId of input.removeIds ?? []) {
+    await deleteTripPlace(userId, placeId);
+  }
+
+  const places = await getTripPlaces(userId, input.tripId);
+
+  return toolResponse({ message: 'Places updated.', places });
+};
+
+// ---------------------------------------------------------------------------
+// travel_get_places
+// ---------------------------------------------------------------------------
+
+export const TravelGetPlacesSchema = z.object({
+  tripId: z.number().int().positive().describe('Trip ID to retrieve places for.'),
+});
+
+export const travelGetPlacesTool: ToolHandler<typeof TravelGetPlacesSchema.shape> = async (input, context) => {
+  const { userId } = context;
+  const places = await getTripPlaces(userId, input.tripId);
+  return toolResponse({ places });
+};

--- a/packages/mcp-server/src/travel/tools/tasks.ts
+++ b/packages/mcp-server/src/travel/tools/tasks.ts
@@ -14,6 +14,7 @@ import {
   suggestChecklistTemplate,
   updateTripCompanion,
 } from '@my-hub/shared/services';
+import type { TripPlace } from '@my-hub/shared/types';
 import { TripDocumentTypes, tripDocumentTypeValues } from '@my-hub/shared/constants';
 import type { TripDocumentType } from '@my-hub/shared/types';
 import { toolResponse } from '../../shared/toolsUtils';
@@ -56,8 +57,20 @@ export const TravelWhoIsTravelingSchema = z.object({
     .describe('Companion ids to remove. If omitted, no removals happen.'),
 });
 
+const TripBriefSectionSchema = z.enum(['bookings', 'checklist', 'companions', 'documents', 'day_notes', 'places']);
+
 export const TravelGetTripBriefSchema = z.object({
   tripId: z.number().int().positive().optional().describe('Trip ID. If omitted, use the next upcoming trip.'),
+  include: z
+    .array(TripBriefSectionSchema)
+    .optional()
+    .describe(
+      'Sections to include in the response. ' +
+        'Omit for a lightweight summary (trip info + counts only). ' +
+        'Pass specific sections when you need full data: ' +
+        '"bookings", "checklist", "companions", "documents", "day_notes", "places". ' +
+        'When "day_notes" is included, each day is enriched with its linked place details.',
+    ),
 });
 
 export const TravelAttachDocumentLinkSchema = z.object({
@@ -171,13 +184,13 @@ export const travelGetTripBriefTool: ToolHandler<typeof TravelGetTripBriefSchema
   const overview = await getTripBrief(userId, input.tripId);
 
   if (!overview) {
-    return toolResponse({
-      message: 'No matching trip found.',
-      trip: null,
-    });
+    return toolResponse({ message: 'No matching trip found.', trip: null });
   }
 
-  return toolResponse({
+  const include = new Set(input.include ?? []);
+  const placesById = new Map<number, TripPlace>(overview.places.map(p => [p.id, p]));
+
+  const response: Record<string, unknown> = {
     message: 'Trip brief generated.',
     trip: overview.trip,
     counts: {
@@ -186,11 +199,23 @@ export const travelGetTripBriefTool: ToolHandler<typeof TravelGetTripBriefSchema
       checklist: overview.checklist.length,
       companions: overview.companions.length,
       documents: overview.documents.length,
+      dayNotes: overview.dayNotes.length,
     },
-    bookings: overview.bookings,
-    checklist: overview.checklist,
-    companions: overview.companions,
-  });
+  };
+
+  if (include.has('bookings')) response.bookings = overview.bookings;
+  if (include.has('checklist')) response.checklist = overview.checklist;
+  if (include.has('companions')) response.companions = overview.companions;
+  if (include.has('documents')) response.documents = overview.documents;
+  if (include.has('places')) response.places = overview.places;
+  if (include.has('day_notes')) {
+    response.dayNotes = overview.dayNotes.map(day => ({
+      ...day,
+      places: (day.placeIds ?? []).map(id => placesById.get(id)).filter(Boolean),
+    }));
+  }
+
+  return toolResponse(response);
 };
 
 export const travelAttachDocumentLinkTool: ToolHandler<typeof TravelAttachDocumentLinkSchema.shape> = async (

--- a/packages/mcp-server/src/travel/tools/tools.ts
+++ b/packages/mcp-server/src/travel/tools/tools.ts
@@ -128,14 +128,19 @@ const travelTools = [
   defineTool({
     name: 'travel_upsert_day_note',
     description:
-      'Create or update a planning note for a specific calendar day within a trip. Use when the user wants to add a title or notes to a particular day.',
+      'Create or update a planning note for a specific calendar day within a trip. ' +
+      'Use when the user wants to add a title, notes, or linked places to a particular day. ' +
+      'To link places: obtain place IDs from travel_get_trip_brief; create new places first if they do not exist yet. ' +
+      'Provide precise location data (street address or lat/lng) when creating places so the map chip works correctly.',
     inputSchema: TravelUpsertDayNoteSchema.shape,
     annotations: { idempotentHint: true, destructiveHint: false },
     callback: travelUpsertDayNoteTool,
   }),
   defineTool({
     name: 'travel_get_day_notes',
-    description: 'Get all day-by-day planning notes for a trip, ordered by date.',
+    description:
+      'Get all day-by-day planning notes for a trip, ordered by date. ' +
+      'Returns each day enriched with full place details for any linked place IDs.',
     inputSchema: TravelGetDayNotesSchema.shape,
     annotations: { readOnlyHint: true },
     callback: travelGetDayNotesTool,

--- a/packages/mcp-server/src/travel/tools/tools.ts
+++ b/packages/mcp-server/src/travel/tools/tools.ts
@@ -22,6 +22,7 @@ import {
   travelGetDayNotesTool,
   travelDeleteDayNoteTool,
 } from './days';
+import { TravelManagePlacesSchema, TravelGetPlacesSchema, travelManagePlacesTool, travelGetPlacesTool } from './places';
 import {
   TravelAttachDocumentLinkSchema,
   TravelGetTripBriefSchema,
@@ -120,7 +121,10 @@ const travelTools = [
   defineTool({
     name: 'travel_get_trip_brief',
     description:
-      'Get a concise trip brief with itinerary counts, checklist, and companions. Defaults to next upcoming trip if tripId is omitted.',
+      'Get a trip summary with counts for all sections (bookings, places, checklist, companions, documents, day notes). ' +
+      'Defaults to the next upcoming trip if tripId is omitted. ' +
+      'Pass include to retrieve full data for specific sections, e.g. include: ["bookings", "day_notes"]. ' +
+      'Use travel_get_places for a standalone place list and travel_get_day_notes for enriched day notes.',
     inputSchema: TravelGetTripBriefSchema.shape,
     annotations: { readOnlyHint: true },
     callback: travelGetTripBriefTool,
@@ -151,6 +155,26 @@ const travelTools = [
     inputSchema: TravelDeleteDayNoteSchema.shape,
     annotations: { idempotentHint: false, destructiveHint: true },
     callback: travelDeleteDayNoteTool,
+  }),
+  defineTool({
+    name: 'travel_manage_places',
+    description:
+      'Add, update, or remove points of interest for a trip in one call. Returns the updated full places list with IDs. ' +
+      'Always provide a precise address (e.g. "Piazza del Colosseo 1, 00184 Rome, Italy") and lat/lng when available — ' +
+      'these power the map chips in the UI. ' +
+      'After adding places, pass their returned IDs to travel_upsert_day_note to link them to specific days.',
+    inputSchema: TravelManagePlacesSchema.shape,
+    annotations: { idempotentHint: false, destructiveHint: false },
+    callback: travelManagePlacesTool,
+  }),
+  defineTool({
+    name: 'travel_get_places',
+    description:
+      'Get all points of interest for a trip with full details (id, name, location, lat/lng, priority, visited). ' +
+      'Use this when you need place IDs to link to day notes, or to check what places already exist before adding.',
+    inputSchema: TravelGetPlacesSchema.shape,
+    annotations: { readOnlyHint: true },
+    callback: travelGetPlacesTool,
   }),
   defineTool({
     name: 'travel_attach_document_link',

--- a/packages/shared/CLAUDE.md
+++ b/packages/shared/CLAUDE.md
@@ -25,7 +25,7 @@
 | `companions.ts`         | Travel companion CRUD: addTripCompanion, getTripCompanions, updateTripCompanion, deleteTripCompanion                                                                                |
 | `days.ts`               | Trip day notes: upsertTripDay (supports placeIds; COALESCE preserves associations when not provided), getTripDays, deleteTripDay                                                    |
 | `documents.ts`          | Document records CRUD: addTripDocument, getTripDocuments, getTripDocumentById, updateTripDocument, deleteTripDocument                                                               |
-| `places.ts`             | Points of interest CRUD: addTripPlace, getTripPlaces (filterable by visited/priority), updateTripPlace, deleteTripPlace                                                             |
+| `places.ts`             | Points of interest CRUD: addTripPlace, getTripPlaces (filterable by visited/priority), updateTripPlace (now includes lat/lng), deleteTripPlace                                      |
 | `shares.ts`             | Trip sharing: listTripShares, createTripShare, deleteTripShare, deleteAllUserTripShares                                                                                             |
 | `semantic.ts`           | Aggregated read queries: getTripOverview, getTripBrief, getTripTimeline, getUpcomingBookings, suggestChecklistTemplate                                                              |
 | `flightData.ts`         | Flight data polling: upsertFlightData, updateFlightData, getFlightDataDueForFetch, computeNextFetchAt, backOffFlightData, setFlightDataAutoUpdate, linkBookingToFlightData          |

--- a/packages/shared/CLAUDE.md
+++ b/packages/shared/CLAUDE.md
@@ -23,7 +23,7 @@
 | `bookings.ts`           | Booking CRUD + filters: addTripBooking, getTripBookings, getUpcomingTripBookings, getTripBookingById, updateTripBooking, deleteTripBooking — coordinate validation on insert/update |
 | `checklist.ts`          | Checklist item CRUD: addChecklistItem, getChecklistItems, updateChecklistItem, toggleChecklistItem, deleteChecklistItem                                                             |
 | `companions.ts`         | Travel companion CRUD: addTripCompanion, getTripCompanions, updateTripCompanion, deleteTripCompanion                                                                                |
-| `days.ts`               | Trip day notes: upsertTripDay, getTripDays, deleteTripDay                                                                                                                           |
+| `days.ts`               | Trip day notes: upsertTripDay (supports placeIds; COALESCE preserves associations when not provided), getTripDays, deleteTripDay                                                    |
 | `documents.ts`          | Document records CRUD: addTripDocument, getTripDocuments, getTripDocumentById, updateTripDocument, deleteTripDocument                                                               |
 | `places.ts`             | Points of interest CRUD: addTripPlace, getTripPlaces (filterable by visited/priority), updateTripPlace, deleteTripPlace                                                             |
 | `shares.ts`             | Trip sharing: listTripShares, createTripShare, deleteTripShare, deleteAllUserTripShares                                                                                             |

--- a/packages/shared/drizzle/0005_chilly_expediter.sql
+++ b/packages/shared/drizzle/0005_chilly_expediter.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "trip_days" ADD COLUMN "place_ids" integer[];

--- a/packages/shared/drizzle/meta/0005_snapshot.json
+++ b/packages/shared/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,5029 @@
+{
+  "id": "85188829-7157-43ae-9c7a-69580bbb05d7",
+  "prevId": "4ef7ecaa-1952-4cd7-b6d9-bb1503d2a99a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "google_id": {
+          "name": "google_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "failed_login_attempts": {
+          "name": "failed_login_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "blocked_at": {
+          "name": "blocked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_clients": {
+      "name": "oauth_clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_signing_secret": {
+          "name": "token_signing_secret",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_clients_user_id_users_id_fk": {
+          "name": "oauth_clients_user_id_users_id_fk",
+          "tableFrom": "oauth_clients",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_clients_client_id_unique": {
+          "name": "oauth_clients_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_refresh_tokens": {
+      "name": "oauth_refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_refresh_tokens_client_id_oauth_clients_client_id_fk": {
+          "name": "oauth_refresh_tokens_client_id_oauth_clients_client_id_fk",
+          "tableFrom": "oauth_refresh_tokens",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_tokens_user_id_users_id_fk": {
+          "name": "oauth_refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "oauth_refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_refresh_tokens_token_hash_unique": {
+          "name": "oauth_refresh_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_servers": {
+      "name": "mcp_servers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "server_name": {
+          "name": "server_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mcp_servers_user_id_users_id_fk": {
+          "name": "mcp_servers_user_id_users_id_fk",
+          "tableFrom": "mcp_servers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_mcp_user_server": {
+          "name": "uq_mcp_user_server",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "server_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calorie_profiles": {
+      "name": "calorie_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "age": {
+          "name": "age",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sex": {
+          "name": "sex",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height_cm": {
+          "name": "height_cm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activity_level": {
+          "name": "activity_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goal_type": {
+          "name": "goal_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goal_weekly_rate_kg": {
+          "name": "goal_weekly_rate_kg",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goal_min_calories": {
+          "name": "goal_min_calories",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goal_max_calories": {
+          "name": "goal_max_calories",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goal_protein": {
+          "name": "goal_protein",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goal_carbs": {
+          "name": "goal_carbs",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goal_fat": {
+          "name": "goal_fat",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "automation_api_key": {
+          "name": "automation_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "calorie_profiles_user_id_users_id_fk": {
+          "name": "calorie_profiles_user_id_users_id_fk",
+          "tableFrom": "calorie_profiles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "calorie_profiles_user_id_unique": {
+          "name": "calorie_profiles_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meal_logs": {
+      "name": "meal_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "meal_id": {
+          "name": "meal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logged_at": {
+          "name": "logged_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "meal_type": {
+          "name": "meal_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kcal": {
+          "name": "kcal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "protein": {
+          "name": "protein",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "carbs": {
+          "name": "carbs",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fat": {
+          "name": "fat",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_meal_logs_user": {
+          "name": "idx_meal_logs_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_meal_logs_date": {
+          "name": "idx_meal_logs_date",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_meal_logs_user_date": {
+          "name": "idx_meal_logs_user_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "meal_logs_user_id_users_id_fk": {
+          "name": "meal_logs_user_id_users_id_fk",
+          "tableFrom": "meal_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "meal_logs_meal_id_unique": {
+          "name": "meal_logs_meal_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "meal_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.body_measurements": {
+      "name": "body_measurements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_key": {
+          "name": "type_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entry_source": {
+          "name": "entry_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'hub'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_body_measurements_user": {
+          "name": "idx_body_measurements_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_body_measurements_date": {
+          "name": "idx_body_measurements_date",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_body_measurements_user_date": {
+          "name": "idx_body_measurements_user_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_body_measurements_user_type": {
+          "name": "idx_body_measurements_user_type",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "body_measurements_user_id_users_id_fk": {
+          "name": "body_measurements_user_id_users_id_fk",
+          "tableFrom": "body_measurements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_request_logs": {
+      "name": "api_request_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "service": {
+          "name": "service",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "server": {
+          "name": "server",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "inet",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_body": {
+          "name": "request_body",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_body": {
+          "name": "response_body",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_logs_created_at": {
+          "name": "idx_logs_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_logs_path": {
+          "name": "idx_logs_path",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_logs_user": {
+          "name": "idx_logs_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_logs_status": {
+          "name": "idx_logs_status",
+          "columns": [
+            {
+              "expression": "status_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_logs_service": {
+          "name": "idx_logs_service",
+          "columns": [
+            {
+              "expression": "service",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_logs_client": {
+          "name": "idx_logs_client",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_logs_server": {
+          "name": "idx_logs_server",
+          "columns": [
+            {
+              "expression": "server",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_request_logs_client_id_oauth_clients_client_id_fk": {
+          "name": "api_request_logs_client_id_oauth_clients_client_id_fk",
+          "tableFrom": "api_request_logs",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.todos": {
+      "name": "todos",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "done": {
+          "name": "done",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "todos_user_id_users_id_fk": {
+          "name": "todos_user_id_users_id_fk",
+          "tableFrom": "todos",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invite_tokens": {
+      "name": "invite_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_by": {
+          "name": "used_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invite_tokens_created_by_users_id_fk": {
+          "name": "invite_tokens_created_by_users_id_fk",
+          "tableFrom": "invite_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invite_tokens_used_by_users_id_fk": {
+          "name": "invite_tokens_used_by_users_id_fk",
+          "tableFrom": "invite_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "used_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invite_tokens_token_unique": {
+          "name": "invite_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.apiary_hives": {
+      "name": "apiary_hives",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "yard_id": {
+          "name": "yard_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "queen_status": {
+          "name": "queen_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "queen_marked": {
+          "name": "queen_marked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "queen_year": {
+          "name": "queen_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "boxes": {
+          "name": "boxes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "apiary_hives_user_id_users_id_fk": {
+          "name": "apiary_hives_user_id_users_id_fk",
+          "tableFrom": "apiary_hives",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "apiary_hives_yard_id_apiary_yards_id_fk": {
+          "name": "apiary_hives_yard_id_apiary_yards_id_fk",
+          "tableFrom": "apiary_hives",
+          "tableTo": "apiary_yards",
+          "columnsFrom": [
+            "yard_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.apiary_logs": {
+      "name": "apiary_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hive_id": {
+          "name": "hive_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logged_at": {
+          "name": "logged_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "apiary_logs_user_id_users_id_fk": {
+          "name": "apiary_logs_user_id_users_id_fk",
+          "tableFrom": "apiary_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "apiary_logs_hive_id_apiary_hives_id_fk": {
+          "name": "apiary_logs_hive_id_apiary_hives_id_fk",
+          "tableFrom": "apiary_logs",
+          "tableTo": "apiary_hives",
+          "columnsFrom": [
+            "hive_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.apiary_tasks": {
+      "name": "apiary_tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hive_id": {
+          "name": "hive_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "yard_id": {
+          "name": "yard_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed": {
+          "name": "completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "apiary_tasks_user_id_users_id_fk": {
+          "name": "apiary_tasks_user_id_users_id_fk",
+          "tableFrom": "apiary_tasks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "apiary_tasks_hive_id_apiary_hives_id_fk": {
+          "name": "apiary_tasks_hive_id_apiary_hives_id_fk",
+          "tableFrom": "apiary_tasks",
+          "tableTo": "apiary_hives",
+          "columnsFrom": [
+            "hive_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "apiary_tasks_yard_id_apiary_yards_id_fk": {
+          "name": "apiary_tasks_yard_id_apiary_yards_id_fk",
+          "tableFrom": "apiary_tasks",
+          "tableTo": "apiary_yards",
+          "columnsFrom": [
+            "yard_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.apiary_yards": {
+      "name": "apiary_yards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "apiary_yards_user_id_users_id_fk": {
+          "name": "apiary_yards_user_id_users_id_fk",
+          "tableFrom": "apiary_yards",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.flight_data": {
+      "name": "flight_data",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "flight_number": {
+          "name": "flight_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flight_date": {
+          "name": "flight_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin_iata": {
+          "name": "origin_iata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destination_iata": {
+          "name": "destination_iata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_departure_at": {
+          "name": "scheduled_departure_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_arrival_at": {
+          "name": "scheduled_arrival_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actual_departure_at": {
+          "name": "actual_departure_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actual_arrival_at": {
+          "name": "actual_arrival_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "departure_terminal": {
+          "name": "departure_terminal",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "departure_gate": {
+          "name": "departure_gate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "arrival_terminal": {
+          "name": "arrival_terminal",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aircraft_type": {
+          "name": "aircraft_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aircraft_registration": {
+          "name": "aircraft_registration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "airline_iata": {
+          "name": "airline_iata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "airline_name": {
+          "name": "airline_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_fetched_at": {
+          "name": "last_fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_fetch_at": {
+          "name": "next_fetch_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_update_enabled": {
+          "name": "auto_update_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "raw_response": {
+          "name": "raw_response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished": {
+          "name": "finished",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uniq_flight_data_number_date": {
+          "name": "uniq_flight_data_number_date",
+          "columns": [
+            {
+              "expression": "flight_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "flight_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_flight_data_next_fetch_at": {
+          "name": "idx_flight_data_next_fetch_at",
+          "columns": [
+            {
+              "expression": "next_fetch_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_flight_data_finished": {
+          "name": "idx_flight_data_finished",
+          "columns": [
+            {
+              "expression": "finished",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trip_bookings": {
+      "name": "trip_bookings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "booking_type": {
+          "name": "booking_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmation_number": {
+          "name": "confirmation_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_at": {
+          "name": "end_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_amount": {
+          "name": "cost_amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_currency": {
+          "name": "cost_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'EUR'"
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_link": {
+          "name": "reference_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flight_data_id": {
+          "name": "flight_data_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lat": {
+          "name": "lat",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lng": {
+          "name": "lng",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_name": {
+          "name": "contact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_trip_bookings_trip_id": {
+          "name": "idx_trip_bookings_trip_id",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_trip_bookings_user_id": {
+          "name": "idx_trip_bookings_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_trip_bookings_start_at": {
+          "name": "idx_trip_bookings_start_at",
+          "columns": [
+            {
+              "expression": "start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trip_bookings_user_id_users_id_fk": {
+          "name": "trip_bookings_user_id_users_id_fk",
+          "tableFrom": "trip_bookings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "trip_bookings_trip_id_trips_id_fk": {
+          "name": "trip_bookings_trip_id_trips_id_fk",
+          "tableFrom": "trip_bookings",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "trip_bookings_flight_data_id_flight_data_id_fk": {
+          "name": "trip_bookings_flight_data_id_flight_data_id_fk",
+          "tableFrom": "trip_bookings",
+          "tableTo": "flight_data",
+          "columnsFrom": [
+            "flight_data_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trip_checklist_items": {
+      "name": "trip_checklist_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "done": {
+          "name": "done",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_trip_checklist_items_trip_id": {
+          "name": "idx_trip_checklist_items_trip_id",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_trip_checklist_items_user_id": {
+          "name": "idx_trip_checklist_items_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trip_checklist_items_user_id_users_id_fk": {
+          "name": "trip_checklist_items_user_id_users_id_fk",
+          "tableFrom": "trip_checklist_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "trip_checklist_items_trip_id_trips_id_fk": {
+          "name": "trip_checklist_items_trip_id_trips_id_fk",
+          "tableFrom": "trip_checklist_items",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trip_companions": {
+      "name": "trip_companions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_trip_companions_trip_id": {
+          "name": "idx_trip_companions_trip_id",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_trip_companions_user_id": {
+          "name": "idx_trip_companions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trip_companions_user_id_users_id_fk": {
+          "name": "trip_companions_user_id_users_id_fk",
+          "tableFrom": "trip_companions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "trip_companions_trip_id_trips_id_fk": {
+          "name": "trip_companions_trip_id_trips_id_fk",
+          "tableFrom": "trip_companions",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trip_days": {
+      "name": "trip_days",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "place_ids": {
+          "name": "place_ids",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uniq_trip_days_trip_date": {
+          "name": "uniq_trip_days_trip_date",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_trip_days_trip_id": {
+          "name": "idx_trip_days_trip_id",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_trip_days_user_id": {
+          "name": "idx_trip_days_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trip_days_user_id_users_id_fk": {
+          "name": "trip_days_user_id_users_id_fk",
+          "tableFrom": "trip_days",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "trip_days_trip_id_trips_id_fk": {
+          "name": "trip_days_trip_id_trips_id_fk",
+          "tableFrom": "trip_days",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trip_documents": {
+      "name": "trip_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_name": {
+          "name": "original_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_path": {
+          "name": "storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_url": {
+          "name": "public_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_trip_documents_trip_id": {
+          "name": "idx_trip_documents_trip_id",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_trip_documents_booking_id": {
+          "name": "idx_trip_documents_booking_id",
+          "columns": [
+            {
+              "expression": "booking_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_trip_documents_user_id": {
+          "name": "idx_trip_documents_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trip_documents_user_id_users_id_fk": {
+          "name": "trip_documents_user_id_users_id_fk",
+          "tableFrom": "trip_documents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "trip_documents_trip_id_trips_id_fk": {
+          "name": "trip_documents_trip_id_trips_id_fk",
+          "tableFrom": "trip_documents",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "trip_documents_booking_id_trip_bookings_id_fk": {
+          "name": "trip_documents_booking_id_trip_bookings_id_fk",
+          "tableFrom": "trip_documents",
+          "tableTo": "trip_bookings",
+          "columnsFrom": [
+            "booking_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trip_places": {
+      "name": "trip_places",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visited": {
+          "name": "visited",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'medium'"
+        },
+        "lat": {
+          "name": "lat",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lng": {
+          "name": "lng",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_trip_places_trip_id": {
+          "name": "idx_trip_places_trip_id",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_trip_places_user_id": {
+          "name": "idx_trip_places_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trip_places_user_id_users_id_fk": {
+          "name": "trip_places_user_id_users_id_fk",
+          "tableFrom": "trip_places",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "trip_places_trip_id_trips_id_fk": {
+          "name": "trip_places_trip_id_trips_id_fk",
+          "tableFrom": "trip_places",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trip_shares": {
+      "name": "trip_shares",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shared_with_user_id": {
+          "name": "shared_with_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission": {
+          "name": "permission",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'view'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uniq_trip_shares_owner_trip_shared_with": {
+          "name": "uniq_trip_shares_owner_trip_shared_with",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "shared_with_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_trip_shares_trip_id": {
+          "name": "idx_trip_shares_trip_id",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_trip_shares_shared_with_user_id": {
+          "name": "idx_trip_shares_shared_with_user_id",
+          "columns": [
+            {
+              "expression": "shared_with_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trip_shares_owner_user_id_users_id_fk": {
+          "name": "trip_shares_owner_user_id_users_id_fk",
+          "tableFrom": "trip_shares",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "trip_shares_trip_id_trips_id_fk": {
+          "name": "trip_shares_trip_id_trips_id_fk",
+          "tableFrom": "trip_shares",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "trip_shares_shared_with_user_id_users_id_fk": {
+          "name": "trip_shares_shared_with_user_id_users_id_fk",
+          "tableFrom": "trip_shares",
+          "tableTo": "users",
+          "columnsFrom": [
+            "shared_with_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trips": {
+      "name": "trips",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#3B82F6'"
+        },
+        "destination": {
+          "name": "destination",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_at": {
+          "name": "end_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_image_url": {
+          "name": "cover_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_trips_user_id": {
+          "name": "idx_trips_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_trips_start_at": {
+          "name": "idx_trips_start_at",
+          "columns": [
+            {
+              "expression": "start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trips_user_id_users_id_fk": {
+          "name": "trips_user_id_users_id_fk",
+          "tableFrom": "trips",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_preferences": {
+      "name": "notification_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscription_key": {
+          "name": "subscription_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscribed": {
+          "name": "subscribed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notif_user_key_idx": {
+          "name": "notif_user_key_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subscription_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_preferences_user_id_users_id_fk": {
+          "name": "notification_preferences_user_id_users_id_fk",
+          "tableFrom": "notification_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.password_reset_tokens": {
+      "name": "password_reset_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "password_reset_tokens_user_id_users_id_fk": {
+          "name": "password_reset_tokens_user_id_users_id_fk",
+          "tableFrom": "password_reset_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "password_reset_tokens_token_unique": {
+          "name": "password_reset_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.finance_account_availability": {
+      "name": "finance_account_availability",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "include": {
+          "name": "include",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "finance_account_availability_user_id_users_id_fk": {
+          "name": "finance_account_availability_user_id_users_id_fk",
+          "tableFrom": "finance_account_availability",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "finance_account_availability_account_id_finance_accounts_id_fk": {
+          "name": "finance_account_availability_account_id_finance_accounts_id_fk",
+          "tableFrom": "finance_account_availability",
+          "tableTo": "finance_accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "finance_account_availability_user_id_account_id_pk": {
+          "name": "finance_account_availability_user_id_account_id_pk",
+          "columns": [
+            "user_id",
+            "account_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.finance_accounts": {
+      "name": "finance_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "budget_id": {
+          "name": "budget_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance": {
+          "name": "balance",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_finance_accounts_budget": {
+          "name": "idx_finance_accounts_budget",
+          "columns": [
+            {
+              "expression": "budget_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_finance_accounts_type": {
+          "name": "idx_finance_accounts_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "finance_accounts_budget_id_finance_budgets_id_fk": {
+          "name": "finance_accounts_budget_id_finance_budgets_id_fk",
+          "tableFrom": "finance_accounts",
+          "tableTo": "finance_budgets",
+          "columnsFrom": [
+            "budget_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.finance_budget_members": {
+      "name": "finance_budget_members",
+      "schema": "",
+      "columns": {
+        "budget_id": {
+          "name": "budget_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "idx_finance_budget_members_budget": {
+          "name": "idx_finance_budget_members_budget",
+          "columns": [
+            {
+              "expression": "budget_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_finance_budget_members_user": {
+          "name": "idx_finance_budget_members_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "finance_budget_members_budget_id_finance_budgets_id_fk": {
+          "name": "finance_budget_members_budget_id_finance_budgets_id_fk",
+          "tableFrom": "finance_budget_members",
+          "tableTo": "finance_budgets",
+          "columnsFrom": [
+            "budget_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "finance_budget_members_user_id_users_id_fk": {
+          "name": "finance_budget_members_user_id_users_id_fk",
+          "tableFrom": "finance_budget_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "finance_budget_members_budget_id_user_id_pk": {
+          "name": "finance_budget_members_budget_id_user_id_pk",
+          "columns": [
+            "budget_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.finance_budgets": {
+      "name": "finance_budgets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_currency": {
+          "name": "default_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MDL'"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "finance_budgets_created_by_user_id_users_id_fk": {
+          "name": "finance_budgets_created_by_user_id_users_id_fk",
+          "tableFrom": "finance_budgets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.finance_categories": {
+      "name": "finance_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "budget_id": {
+          "name": "budget_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "monthly_target": {
+          "name": "monthly_target",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_finance_categories_budget": {
+          "name": "idx_finance_categories_budget",
+          "columns": [
+            {
+              "expression": "budget_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_finance_categories_group": {
+          "name": "idx_finance_categories_group",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "finance_categories_budget_id_finance_budgets_id_fk": {
+          "name": "finance_categories_budget_id_finance_budgets_id_fk",
+          "tableFrom": "finance_categories",
+          "tableTo": "finance_budgets",
+          "columnsFrom": [
+            "budget_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "finance_categories_group_id_finance_groups_id_fk": {
+          "name": "finance_categories_group_id_finance_groups_id_fk",
+          "tableFrom": "finance_categories",
+          "tableTo": "finance_groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.finance_currency_rates": {
+      "name": "finance_currency_rates",
+      "schema": "",
+      "columns": {
+        "from_currency": {
+          "name": "from_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_currency": {
+          "name": "to_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rate": {
+          "name": "rate",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "finance_currency_rates_from_currency_to_currency_date_pk": {
+          "name": "finance_currency_rates_from_currency_to_currency_date_pk",
+          "columns": [
+            "from_currency",
+            "to_currency",
+            "date"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.finance_groups": {
+      "name": "finance_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "budget_id": {
+          "name": "budget_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_finance_groups_budget": {
+          "name": "idx_finance_groups_budget",
+          "columns": [
+            {
+              "expression": "budget_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "finance_groups_budget_id_finance_budgets_id_fk": {
+          "name": "finance_groups_budget_id_finance_budgets_id_fk",
+          "tableFrom": "finance_groups",
+          "tableTo": "finance_budgets",
+          "columnsFrom": [
+            "budget_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.finance_import_batches": {
+      "name": "finance_import_batches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "budget_id": {
+          "name": "budget_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "imported_count": {
+          "name": "imported_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'completed'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_finance_import_batches_budget": {
+          "name": "idx_finance_import_batches_budget",
+          "columns": [
+            {
+              "expression": "budget_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_finance_import_batches_user": {
+          "name": "idx_finance_import_batches_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "finance_import_batches_budget_id_finance_budgets_id_fk": {
+          "name": "finance_import_batches_budget_id_finance_budgets_id_fk",
+          "tableFrom": "finance_import_batches",
+          "tableTo": "finance_budgets",
+          "columnsFrom": [
+            "budget_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "finance_import_batches_user_id_users_id_fk": {
+          "name": "finance_import_batches_user_id_users_id_fk",
+          "tableFrom": "finance_import_batches",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.finance_labels": {
+      "name": "finance_labels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "budget_id": {
+          "name": "budget_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "uq_finance_labels_budget_label": {
+          "name": "uq_finance_labels_budget_label",
+          "columns": [
+            {
+              "expression": "budget_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "label",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_finance_labels_budget": {
+          "name": "idx_finance_labels_budget",
+          "columns": [
+            {
+              "expression": "budget_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "finance_labels_budget_id_finance_budgets_id_fk": {
+          "name": "finance_labels_budget_id_finance_budgets_id_fk",
+          "tableFrom": "finance_labels",
+          "tableTo": "finance_budgets",
+          "columnsFrom": [
+            "budget_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.finance_monthly_plan_items": {
+      "name": "finance_monthly_plan_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merchant_id": {
+          "name": "merchant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_account_id": {
+          "name": "linked_account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_amount": {
+          "name": "assigned_amount",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_assigned": {
+          "name": "is_assigned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "assigned_transaction_id": {
+          "name": "assigned_transaction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_finance_plan_items_plan": {
+          "name": "idx_finance_plan_items_plan",
+          "columns": [
+            {
+              "expression": "plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_finance_plan_items_linked_account": {
+          "name": "idx_finance_plan_items_linked_account",
+          "columns": [
+            {
+              "expression": "linked_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "finance_monthly_plan_items_plan_id_finance_monthly_plans_id_fk": {
+          "name": "finance_monthly_plan_items_plan_id_finance_monthly_plans_id_fk",
+          "tableFrom": "finance_monthly_plan_items",
+          "tableTo": "finance_monthly_plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "finance_monthly_plan_items_category_id_finance_categories_id_fk": {
+          "name": "finance_monthly_plan_items_category_id_finance_categories_id_fk",
+          "tableFrom": "finance_monthly_plan_items",
+          "tableTo": "finance_categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "finance_monthly_plan_items_merchant_id_finance_payees_id_fk": {
+          "name": "finance_monthly_plan_items_merchant_id_finance_payees_id_fk",
+          "tableFrom": "finance_monthly_plan_items",
+          "tableTo": "finance_payees",
+          "columnsFrom": [
+            "merchant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "finance_monthly_plan_items_linked_account_id_finance_accounts_id_fk": {
+          "name": "finance_monthly_plan_items_linked_account_id_finance_accounts_id_fk",
+          "tableFrom": "finance_monthly_plan_items",
+          "tableTo": "finance_accounts",
+          "columnsFrom": [
+            "linked_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "finance_monthly_plan_items_assigned_transaction_id_finance_transactions_id_fk": {
+          "name": "finance_monthly_plan_items_assigned_transaction_id_finance_transactions_id_fk",
+          "tableFrom": "finance_monthly_plan_items",
+          "tableTo": "finance_transactions",
+          "columnsFrom": [
+            "assigned_transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.finance_monthly_plans": {
+      "name": "finance_monthly_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "budget_id": {
+          "name": "budget_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "month": {
+          "name": "month",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "available_amount": {
+          "name": "available_amount",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "income_account_id": {
+          "name": "income_account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_finance_monthly_plan_budget_month": {
+          "name": "uq_finance_monthly_plan_budget_month",
+          "columns": [
+            {
+              "expression": "budget_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_finance_monthly_plans_budget": {
+          "name": "idx_finance_monthly_plans_budget",
+          "columns": [
+            {
+              "expression": "budget_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "finance_monthly_plans_budget_id_finance_budgets_id_fk": {
+          "name": "finance_monthly_plans_budget_id_finance_budgets_id_fk",
+          "tableFrom": "finance_monthly_plans",
+          "tableTo": "finance_budgets",
+          "columnsFrom": [
+            "budget_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "finance_monthly_plans_income_account_id_finance_accounts_id_fk": {
+          "name": "finance_monthly_plans_income_account_id_finance_accounts_id_fk",
+          "tableFrom": "finance_monthly_plans",
+          "tableTo": "finance_accounts",
+          "columnsFrom": [
+            "income_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.finance_net_worth_snapshots": {
+      "name": "finance_net_worth_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "budget_id": {
+          "name": "budget_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "month": {
+          "name": "month",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_assets": {
+          "name": "total_assets",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_liabilities": {
+          "name": "total_liabilities",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "net_worth": {
+          "name": "net_worth",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "breakdown": {
+          "name": "breakdown",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_finance_net_worth_budget_month": {
+          "name": "uq_finance_net_worth_budget_month",
+          "columns": [
+            {
+              "expression": "budget_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_finance_net_worth_budget": {
+          "name": "idx_finance_net_worth_budget",
+          "columns": [
+            {
+              "expression": "budget_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "finance_net_worth_snapshots_budget_id_finance_budgets_id_fk": {
+          "name": "finance_net_worth_snapshots_budget_id_finance_budgets_id_fk",
+          "tableFrom": "finance_net_worth_snapshots",
+          "tableTo": "finance_budgets",
+          "columnsFrom": [
+            "budget_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.finance_payees": {
+      "name": "finance_payees",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "budget_id": {
+          "name": "budget_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aliases": {
+          "name": "aliases",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "normalized_name": {
+          "name": "normalized_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_finance_payees_budget_norm": {
+          "name": "uq_finance_payees_budget_norm",
+          "columns": [
+            {
+              "expression": "budget_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "normalized_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_finance_payees_budget": {
+          "name": "idx_finance_payees_budget",
+          "columns": [
+            {
+              "expression": "budget_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "finance_payees_budget_id_finance_budgets_id_fk": {
+          "name": "finance_payees_budget_id_finance_budgets_id_fk",
+          "tableFrom": "finance_payees",
+          "tableTo": "finance_budgets",
+          "columnsFrom": [
+            "budget_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.finance_transactions": {
+      "name": "finance_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "budget_id": {
+          "name": "budget_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_account_id": {
+          "name": "to_account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exchange_rate": {
+          "name": "exchange_rate",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "to_exchange_rate": {
+          "name": "to_exchange_rate",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payee_id": {
+          "name": "payee_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "labels": {
+          "name": "labels",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "extras": {
+          "name": "extras",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_correction": {
+          "name": "is_correction",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "from_account_balance_after": {
+          "name": "from_account_balance_after",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_account_balance_after": {
+          "name": "to_account_balance_after",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'hub'"
+        },
+        "added_by_user_id": {
+          "name": "added_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "import_batch_id": {
+          "name": "import_batch_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_finance_txns_budget": {
+          "name": "idx_finance_txns_budget",
+          "columns": [
+            {
+              "expression": "budget_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_finance_txns_account": {
+          "name": "idx_finance_txns_account",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_finance_txns_to_account": {
+          "name": "idx_finance_txns_to_account",
+          "columns": [
+            {
+              "expression": "to_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_finance_txns_date": {
+          "name": "idx_finance_txns_date",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_finance_txns_category": {
+          "name": "idx_finance_txns_category",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_finance_txns_payee": {
+          "name": "idx_finance_txns_payee",
+          "columns": [
+            {
+              "expression": "payee_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_finance_txns_added_by": {
+          "name": "idx_finance_txns_added_by",
+          "columns": [
+            {
+              "expression": "added_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_finance_txns_import_batch": {
+          "name": "idx_finance_txns_import_batch",
+          "columns": [
+            {
+              "expression": "import_batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_finance_txns_budget_date": {
+          "name": "idx_finance_txns_budget_date",
+          "columns": [
+            {
+              "expression": "budget_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_finance_txns_is_correction": {
+          "name": "idx_finance_txns_is_correction",
+          "columns": [
+            {
+              "expression": "is_correction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"finance_transactions\".\"is_correction\" IS TRUE",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "finance_transactions_budget_id_finance_budgets_id_fk": {
+          "name": "finance_transactions_budget_id_finance_budgets_id_fk",
+          "tableFrom": "finance_transactions",
+          "tableTo": "finance_budgets",
+          "columnsFrom": [
+            "budget_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "finance_transactions_account_id_finance_accounts_id_fk": {
+          "name": "finance_transactions_account_id_finance_accounts_id_fk",
+          "tableFrom": "finance_transactions",
+          "tableTo": "finance_accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "finance_transactions_to_account_id_finance_accounts_id_fk": {
+          "name": "finance_transactions_to_account_id_finance_accounts_id_fk",
+          "tableFrom": "finance_transactions",
+          "tableTo": "finance_accounts",
+          "columnsFrom": [
+            "to_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "finance_transactions_category_id_finance_categories_id_fk": {
+          "name": "finance_transactions_category_id_finance_categories_id_fk",
+          "tableFrom": "finance_transactions",
+          "tableTo": "finance_categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "finance_transactions_payee_id_finance_payees_id_fk": {
+          "name": "finance_transactions_payee_id_finance_payees_id_fk",
+          "tableFrom": "finance_transactions",
+          "tableTo": "finance_payees",
+          "columnsFrom": [
+            "payee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "finance_transactions_added_by_user_id_users_id_fk": {
+          "name": "finance_transactions_added_by_user_id_users_id_fk",
+          "tableFrom": "finance_transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "added_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "finance_transactions_import_batch_id_finance_import_batches_id_fk": {
+          "name": "finance_transactions_import_batch_id_finance_import_batches_id_fk",
+          "tableFrom": "finance_transactions",
+          "tableTo": "finance_import_batches",
+          "columnsFrom": [
+            "import_batch_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/shared/drizzle/meta/_journal.json
+++ b/packages/shared/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1779279675185,
       "tag": "0004_tense_psynapse",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1780080263963,
+      "tag": "0005_chilly_expediter",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/shared/src/db/schema/travel.ts
+++ b/packages/shared/src/db/schema/travel.ts
@@ -237,6 +237,7 @@ export const tripDays = pgTable(
     date: date('date').notNull(), // calendar date, e.g. '2026-06-21'
     title: text('title'),
     notes: text('notes'),
+    placeIds: integer('place_ids').array(),
     createdAt: timestamp('created_at').notNull().defaultNow(),
     updatedAt: timestamp('updated_at').notNull().defaultNow(),
   },

--- a/packages/shared/src/services/travel/days.ts
+++ b/packages/shared/src/services/travel/days.ts
@@ -1,6 +1,6 @@
 /**
  * Trip day notes CRUD
- * - upsertTripDay(userId, tripId, date, data) — creates or updates notes for a calendar day
+ * - upsertTripDay(userId, tripId, date, data) — creates or updates notes for a calendar day; placeIds preserved when not provided
  * - getTripDays(userId, tripId) — lists all day records for a trip, sorted by date
  * - deleteTripDay(userId, dayId) — hard delete
  * - deleteAllUserTripDays(userId) — bulk delete for account removal
@@ -15,6 +15,8 @@ import { verifyTripOwnership } from './trips';
 export interface TripDayUpsert {
   title?: string | null;
   notes?: string | null;
+  /** Place IDs to associate with this day. Pass undefined to preserve existing associations; pass [] to clear. */
+  placeIds?: number[] | null;
 }
 
 export async function upsertTripDay(
@@ -36,6 +38,7 @@ export async function upsertTripDay(
       date,
       title: data.title ?? null,
       notes: data.notes ?? null,
+      placeIds: data.placeIds ?? null,
       createdAt: now,
       updatedAt: now,
     })
@@ -44,6 +47,8 @@ export async function upsertTripDay(
       set: {
         title: sql`excluded.title`,
         notes: sql`excluded.notes`,
+        // Preserve existing placeIds when null is inserted (Hub UI edits don't touch place associations)
+        placeIds: sql`COALESCE(excluded.place_ids, ${tripDays.placeIds})`,
         updatedAt: sql`excluded.updated_at`,
       },
     })

--- a/packages/shared/src/services/travel/places.ts
+++ b/packages/shared/src/services/travel/places.ts
@@ -15,7 +15,9 @@ import type { NewTripPlace, TripPlace, TripPlacePriority } from '../../types';
 import { verifyTripOwnership } from './trips';
 
 export type TripPlaceInsert = Omit<NewTripPlace, 'id' | 'userId' | 'tripId' | 'createdAt' | 'updatedAt'>;
-export type TripPlaceUpdate = Partial<Pick<TripPlaceInsert, 'name' | 'location' | 'notes' | 'visited' | 'priority'>>;
+export type TripPlaceUpdate = Partial<
+  Pick<TripPlaceInsert, 'name' | 'location' | 'notes' | 'visited' | 'priority' | 'lat' | 'lng'>
+>;
 
 export interface GetTripPlacesOpts {
   visited?: boolean;


### PR DESCRIPTION
Adds a place_ids integer[] column to trip_days so AI can associate
trip places with specific days. Day cards in Hub now render linked
places as amber clickable chips (PinIcon) that open Google Maps.

- Schema: `place_ids integer[]` on trip_days; migration generated
- Service: upsertTripDay accepts placeIds; COALESCE in conflict update
  preserves associations when Hub UI saves without placeIds field
- MCP: travel_upsert_day_note accepts placeIds with AI guidance to
  use precise addresses/coords; travel_get_day_notes returns days
  enriched with full place details
- Hub API: days POST accepts and passes through placeIds
- Hub UI: DayByDay renders place chips; getPlaceMapUrl prefers lat/lng
  then falls back to location text or place name

https://claude.ai/code/session_01MSzStueq1cdZir6Jw74vGw