### PR TITLE
fix: preserve title/notes on upsert day when not provided

### DIFF
--- a/packages/hub/src/app/api/travel/trips/[id]/days/route.ts
+++ b/packages/hub/src/app/api/travel/trips/[id]/days/route.ts
@@ -17,8 +17,8 @@ export const POST = route({ params: z.object({ id: z.coerce.number().int().posit
   async ({ user, params, body }) => {
     const tripId = params.id;
     const day = await upsertTripDay(user.id, tripId, body.date, {
-      title: body.title ?? null,
-      notes: body.notes ?? null,
+      title: body.title,
+      notes: body.notes,
       placeIds: body.placeIds,
     });
     return { day };

--- a/packages/mcp-server/src/travel/tools/days.ts
+++ b/packages/mcp-server/src/travel/tools/days.ts
@@ -40,8 +40,8 @@ export const travelUpsertDayNoteTool: ToolHandler<typeof TravelUpsertDayNoteSche
   const { userId } = context;
 
   const day = await upsertTripDay(userId, input.tripId, input.date, {
-    title: input.title ?? null,
-    notes: input.notes ?? null,
+    title: input.title,
+    notes: input.notes,
     placeIds: input.placeIds,
   });
 

--- a/packages/shared/src/services/travel/days.ts
+++ b/packages/shared/src/services/travel/days.ts
@@ -45,8 +45,9 @@ export async function upsertTripDay(
     .onConflictDoUpdate({
       target: [tripDays.tripId, tripDays.date],
       set: {
-        title: sql`excluded.title`,
-        notes: sql`excluded.notes`,
+        // undefined means "not provided — preserve existing"; null means "explicitly clear"
+        title: data.title === undefined ? tripDays.title : sql`excluded.title`,
+        notes: data.notes === undefined ? tripDays.notes : sql`excluded.notes`,
         // Preserve existing placeIds when null is inserted (Hub UI edits don't touch place associations)
         placeIds: sql`COALESCE(excluded.place_ids, ${tripDays.placeIds})`,
         updatedAt: sql`excluded.updated_at`,


### PR DESCRIPTION
`undefined` fields were being coerced to `null` before reaching the service,
causing the upsert to overwrite existing title/notes with null instead of
leaving them untouched. The service conflict handler now conditionally
preserves the existing column value when the field is `undefined`, and the
MCP tool handler / Hub route no longer convert absent fields to `null`.

https://claude.ai/code/session_015LP4odEeNkPs5bnQXgKow1