### PR TITLE
fix: skip conversion metadata when MCP transaction currency matches account currency

### DIFF
--- a/packages/shared/src/services/finances/transactions.ts
+++ b/packages/shared/src/services/finances/transactions.ts
@@ -322,22 +322,24 @@ export async function addTransaction(
     let resolvedExtras = data.extras;
 
     if (originalCurrency != null) {
-      const originalToAccountRate =
-        originalCurrency !== fromAccount.currency
-          ? await getExchangeRate(originalCurrency, fromAccount.currency, data.date)
-          : 1;
+      const needsConversion = originalCurrency !== fromAccount.currency;
+      const originalToAccountRate = needsConversion
+        ? await getExchangeRate(originalCurrency, fromAccount.currency, data.date)
+        : 1;
       effectiveAmount = Math.round(amt * originalToAccountRate * 10000) / 10000;
-      resolvedExtras = {
-        ...(data.extras ?? { kind: 'base' }),
-        conversion: {
-          ...(data.extras?.conversion ?? {}),
-          originalAmount: amt,
-          originalCurrency,
-          accountCurrency: fromAccount.currency,
-          originalToAccountRate,
-          convertedAmount: effectiveAmount,
-        },
-      } as TransactionInsert['extras'];
+      if (needsConversion) {
+        resolvedExtras = {
+          ...(data.extras ?? { kind: 'base' }),
+          conversion: {
+            ...(data.extras?.conversion ?? {}),
+            originalAmount: amt,
+            originalCurrency,
+            accountCurrency: fromAccount.currency,
+            originalToAccountRate,
+            convertedAmount: effectiveAmount,
+          },
+        } as TransactionInsert['extras'];
+      }
     }
 
     const resolvedExchangeRate =


### PR DESCRIPTION
When the supplied currency equals the account currency, the FX rate is 1
and no conversion is happening — writing the full conversion block to extras
was causing the UI to show a spurious "Currency Conversion" section.

https://claude.ai/code/session_01VMKtgJUKvCBeKrpJofQqrg