### PR TITLE
Add Account and Category filters to transaction screen

### DIFF
--- a/packages/hub/src/app/finances/transactions/TransactionFilters.tsx
+++ b/packages/hub/src/app/finances/transactions/TransactionFilters.tsx
@@ -11,6 +11,7 @@ import type { BudgetDetailResponse } from '@/app/api/finances/budget/route';
 import type { LabelsResponse } from '@/app/api/finances/labels/route';
 import type { TransactionFormDataResponse } from '@/app/api/finances/transactions/form-data/route';
 import { TRANSACTION_TYPE_COLORS } from '../finances.utils';
+import { sortAccountsByGroup } from '../accounts/accounts.utils';
 
 type Filter = 'all' | TransactionType;
 
@@ -74,7 +75,7 @@ export function TransactionFilters({ typeFilter, extraValues, onTypeChange, onEx
       .catch(() => {});
     apiFetch<TransactionFormDataResponse>('/api/finances/transactions/form-data', { silentToast: true })
       .then(r => {
-        setAccounts(r.accounts.filter(a => !a.archived).map(a => ({ id: a.id, name: a.name })));
+        setAccounts(sortAccountsByGroup(r.accounts.filter(a => !a.archived)).map(a => ({ id: a.id, name: a.name })));
         setCategories(r.categories.map(c => ({ id: c.id, name: c.name })));
       })
       .catch(() => {});

--- a/packages/hub/src/app/finances/transactions/TransactionFilters.tsx
+++ b/packages/hub/src/app/finances/transactions/TransactionFilters.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react';
 import { cn, apiFetch } from '@/lib/utils';
 import { Input } from '@/components';
-import { FinFieldCard } from '../ui';
+import { FinFieldCard, renderAccountOption, renderCategoryOption } from '../ui';
 import { FinancialDropdown } from '../FinancialDropdown';
 import { finDropdownInputClass } from '../finances.utils';
 import { TransactionType, TransactionTypes } from '@my-hub/shared/constants';
@@ -26,8 +26,8 @@ export type ExtraFilterValues = {
 };
 
 type Member = { userId: string; name: string | null; email: string; initials: string };
-type AccountOption = { id: number; name: string };
-type CategoryOption = { id: number; name: string };
+type AccountOption = { id: number; name: string; type: string; currency: string };
+type CategoryOption = { id: number; name: string; icon: string | null; color: string | null };
 
 type TransactionFiltersProps = {
   typeFilter: Filter;
@@ -75,8 +75,15 @@ export function TransactionFilters({ typeFilter, extraValues, onTypeChange, onEx
       .catch(() => {});
     apiFetch<TransactionFormDataResponse>('/api/finances/transactions/form-data', { silentToast: true })
       .then(r => {
-        setAccounts(sortAccountsByGroup(r.accounts.filter(a => !a.archived)).map(a => ({ id: a.id, name: a.name })));
-        setCategories(r.categories.map(c => ({ id: c.id, name: c.name })));
+        setAccounts(
+          sortAccountsByGroup(r.accounts.filter(a => !a.archived)).map(a => ({
+            id: a.id,
+            name: a.name,
+            type: a.type,
+            currency: a.currency,
+          })),
+        );
+        setCategories(r.categories.map(c => ({ id: c.id, name: c.name, icon: c.icon, color: c.color })));
       })
       .catch(() => {});
   }, []);
@@ -173,6 +180,7 @@ export function TransactionFilters({ typeFilter, extraValues, onTypeChange, onEx
             options={accounts.map(a => ({ id: a.id, value: a.name }))}
             value={extraValues.accountId ? Number(extraValues.accountId) : undefined}
             onChange={item => onExtraChange({ accountId: item ? String(item.id) : '' })}
+            renderOption={item => renderAccountOption(item, accounts)}
             placeholder="All accounts"
             clearable
             clearAriaLabel="Clear account filter"
@@ -186,6 +194,7 @@ export function TransactionFilters({ typeFilter, extraValues, onTypeChange, onEx
             options={categories.map(c => ({ id: c.id, value: c.name }))}
             value={extraValues.categoryId ? Number(extraValues.categoryId) : undefined}
             onChange={item => onExtraChange({ categoryId: item ? String(item.id) : '' })}
+            renderOption={item => renderCategoryOption(item, categories)}
             placeholder="All categories"
             clearable
             clearAriaLabel="Clear category filter"

--- a/packages/hub/src/app/finances/transactions/TransactionFilters.tsx
+++ b/packages/hub/src/app/finances/transactions/TransactionFilters.tsx
@@ -9,12 +9,15 @@ import { finDropdownInputClass } from '../finances.utils';
 import { TransactionType, TransactionTypes } from '@my-hub/shared/constants';
 import type { BudgetDetailResponse } from '@/app/api/finances/budget/route';
 import type { LabelsResponse } from '@/app/api/finances/labels/route';
+import type { TransactionFormDataResponse } from '@/app/api/finances/transactions/form-data/route';
 import { TRANSACTION_TYPE_COLORS } from '../finances.utils';
 
 type Filter = 'all' | TransactionType;
 
 export type ExtraFilterValues = {
   addedByUserId: string;
+  accountId: string;
+  categoryId: string;
   label: string;
   amountGte: string;
   amountLte: string;
@@ -22,6 +25,8 @@ export type ExtraFilterValues = {
 };
 
 type Member = { userId: string; name: string | null; email: string; initials: string };
+type AccountOption = { id: number; name: string };
+type CategoryOption = { id: number; name: string };
 
 type TransactionFiltersProps = {
   typeFilter: Filter;
@@ -48,6 +53,8 @@ const FIELD_INPUT =
 export function TransactionFilters({ typeFilter, extraValues, onTypeChange, onExtraChange }: TransactionFiltersProps) {
   const [members, setMembers] = useState<Member[]>([]);
   const [labels, setLabels] = useState<string[]>([]);
+  const [accounts, setAccounts] = useState<AccountOption[]>([]);
+  const [categories, setCategories] = useState<CategoryOption[]>([]);
 
   useEffect(() => {
     apiFetch<BudgetDetailResponse>('/api/finances/budget', { silentToast: true })
@@ -65,11 +72,19 @@ export function TransactionFilters({ typeFilter, extraValues, onTypeChange, onEx
     apiFetch<LabelsResponse>('/api/finances/labels', { silentToast: true })
       .then(r => setLabels(r.labels))
       .catch(() => {});
+    apiFetch<TransactionFormDataResponse>('/api/finances/transactions/form-data', { silentToast: true })
+      .then(r => {
+        setAccounts(r.accounts.filter(a => !a.archived).map(a => ({ id: a.id, name: a.name })));
+        setCategories(r.categories.map(c => ({ id: c.id, name: c.name })));
+      })
+      .catch(() => {});
   }, []);
 
   const activeCount = [
     typeFilter !== 'all',
     !!extraValues.addedByUserId,
+    !!extraValues.accountId,
+    !!extraValues.categoryId,
     !!extraValues.label,
     !!extraValues.amountGte,
     !!extraValues.amountLte,
@@ -78,7 +93,15 @@ export function TransactionFilters({ typeFilter, extraValues, onTypeChange, onEx
 
   function clearAll() {
     onTypeChange('all');
-    onExtraChange({ addedByUserId: '', label: '', amountGte: '', amountLte: '', search: '' });
+    onExtraChange({
+      addedByUserId: '',
+      accountId: '',
+      categoryId: '',
+      label: '',
+      amountGte: '',
+      amountLte: '',
+      search: '',
+    });
   }
 
   return (
@@ -142,6 +165,32 @@ export function TransactionFilters({ typeFilter, extraValues, onTypeChange, onEx
             </div>
           </FinFieldCard>
         )}
+
+        {/* Account */}
+        <FinFieldCard label="Account">
+          <FinancialDropdown
+            options={accounts.map(a => ({ id: a.id, value: a.name }))}
+            value={extraValues.accountId ? Number(extraValues.accountId) : undefined}
+            onChange={item => onExtraChange({ accountId: item ? String(item.id) : '' })}
+            placeholder="All accounts"
+            clearable
+            clearAriaLabel="Clear account filter"
+            inputClassName={finDropdownInputClass}
+          />
+        </FinFieldCard>
+
+        {/* Category */}
+        <FinFieldCard label="Category">
+          <FinancialDropdown
+            options={categories.map(c => ({ id: c.id, value: c.name }))}
+            value={extraValues.categoryId ? Number(extraValues.categoryId) : undefined}
+            onChange={item => onExtraChange({ categoryId: item ? String(item.id) : '' })}
+            placeholder="All categories"
+            clearable
+            clearAriaLabel="Clear category filter"
+            inputClassName={finDropdownInputClass}
+          />
+        </FinFieldCard>
 
         {/* Label */}
         <FinFieldCard label="Label">

--- a/packages/hub/src/app/finances/transactions/page.tsx
+++ b/packages/hub/src/app/finances/transactions/page.tsx
@@ -23,7 +23,15 @@ function currentMonthStr(): string {
   return dateToString().slice(0, 7);
 }
 
-const EMPTY_EXTRA: ExtraFilterValues = { addedByUserId: '', label: '', amountGte: '', amountLte: '', search: '' };
+const EMPTY_EXTRA: ExtraFilterValues = {
+  addedByUserId: '',
+  accountId: '',
+  categoryId: '',
+  label: '',
+  amountGte: '',
+  amountLte: '',
+  search: '',
+};
 
 export default function TransactionsPage() {
   const router = useRouter();
@@ -47,6 +55,8 @@ export default function TransactionsPage() {
     typeFilter !== 'all',
     dateMode !== 'month',
     !!extra.addedByUserId,
+    !!extra.accountId,
+    !!extra.categoryId,
     !!extra.label,
     !!extra.amountGte,
     !!extra.amountLte,
@@ -170,6 +180,8 @@ export default function TransactionsPage() {
           toDate={dateMode === 'range' ? toDate : undefined}
           type={typeFilter === 'all' ? undefined : typeFilter}
           addedByUserId={extra.addedByUserId || undefined}
+          accountId={extra.accountId ? Number(extra.accountId) : undefined}
+          categoryId={extra.categoryId ? Number(extra.categoryId) : undefined}
           label={extra.label || undefined}
           amountGte={debouncedAmountGte ? parseFloat(debouncedAmountGte) : undefined}
           amountLte={debouncedAmountLte ? parseFloat(debouncedAmountLte) : undefined}


### PR DESCRIPTION
Extends ExtraFilterValues with accountId and categoryId, fetches
accounts and categories from the form-data endpoint, and renders
two new FinancialDropdown filters in the filter panel.

https://claude.ai/code/session_01XRGrjTGkREAJqQQQVxoPbc