### PR TITLE
Use Card component on travel screens and fix mobile modal keyboard behavior

### DIFF
--- a/packages/hub/src/app/layout.tsx
+++ b/packages/hub/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import '@/styles/globals.css';
-import type { Metadata } from 'next';
+import type { Metadata, Viewport } from 'next';
 import { headers } from 'next/headers';
 import { Providers } from '@/components';
 
@@ -11,6 +11,13 @@ export const metadata: Metadata = {
     statusBarStyle: 'black-translucent',
     title: 'My Hub',
   },
+};
+
+export const viewport: Viewport = {
+  // Only the visual viewport shrinks when the virtual keyboard appears;
+  // the layout viewport (and thus fixed-position elements) stays unchanged.
+  // Prevents fixed modals from jumping when keyboard opens on Android Chrome.
+  interactiveWidget: 'resizes-visual',
 };
 
 export default async function RootLayout({ children }: { children: React.ReactNode }) {

--- a/packages/hub/src/app/travel/BookingsSection.tsx
+++ b/packages/hub/src/app/travel/BookingsSection.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useState } from 'react';
-import { SectionCard } from '@/components/SectionCard';
+import { Card } from '@/components';
+import { TravelSectionHeader } from './ui';
 import { Button, ConfirmModal, IconButton, SwipeRow } from '@/components';
 import { AttachmentIcon, PencilIcon, TrashIcon } from '@/components/icons';
 import { BookingTypeIcon } from '@/components';
@@ -78,8 +79,9 @@ export function BookingsSection({
         />
       )}
 
-      <SectionCard title="Reservations" className="bg-[var(--card)] border-[var(--border)]" action={headerAction}>
-        <div className="max-h-[28rem] space-y-2 overflow-auto">
+      <Card className="!p-0 overflow-hidden">
+        <TravelSectionHeader title="Reservations" action={headerAction} />
+        <div className="max-h-[28rem] space-y-2 overflow-auto p-4">
           {bookings.map(booking => (
             <div
               key={booking.id}
@@ -121,7 +123,7 @@ export function BookingsSection({
           ))}
           {bookings.length === 0 && <p className="text-sm text-[var(--muted)]">No reservations yet.</p>}
         </div>
-      </SectionCard>
+      </Card>
     </>
   );
 }

--- a/packages/hub/src/app/travel/ChecklistSection.tsx
+++ b/packages/hub/src/app/travel/ChecklistSection.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useState } from 'react';
-import { SectionCard } from '@/components/SectionCard';
+import { Card } from '@/components';
+import { TravelSectionHeader } from './ui';
 import type { TripChecklistItem } from '@my-hub/shared/types';
 import { Button, ConfirmModal, SwipeRow } from '@/components';
 import { PencilIcon, TrashOutlineIcon } from '@/components/icons';
@@ -71,8 +72,9 @@ export function ChecklistSection({ activeTripId, canEdit, checklist, onChanged }
         />
       )}
 
-      <SectionCard title="Checklist" className="bg-[var(--card)] border-[var(--border)]" action={headerAction}>
-        <div className="max-h-64 space-y-1.5 overflow-auto">
+      <Card className="!p-0 overflow-hidden">
+        <TravelSectionHeader title="Checklist" action={headerAction} />
+        <div className="max-h-64 space-y-1.5 overflow-auto p-4">
           {checklist.map(item => (
             <div key={item.id} className="overflow-hidden rounded-md border border-[var(--border)]">
               {/* Mobile: swipe-to-reveal */}
@@ -136,7 +138,7 @@ export function ChecklistSection({ activeTripId, canEdit, checklist, onChanged }
           ))}
           {checklist.length === 0 && <p className="text-sm text-[var(--muted)]">No checklist items yet.</p>}
         </div>
-      </SectionCard>
+      </Card>
     </>
   );
 }

--- a/packages/hub/src/app/travel/ComingNext.tsx
+++ b/packages/hub/src/app/travel/ComingNext.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { SectionCard } from '@/components/SectionCard';
+import { Card } from '@/components';
+import { TravelSectionHeader } from './ui';
 import { BookingTypeIcon, Button } from '@/components';
 import { TicketIcon, DocumentIcon, ClipboardIcon, PinIcon, PhoneIcon, MailOutlineIcon } from '@/components/icons';
 import type { TripDocument } from '@my-hub/shared/types';
@@ -246,23 +247,26 @@ export function ComingNext({ bookings, documents }: ComingNextProps) {
   if (segments.length === 0) return null;
 
   return (
-    <SectionCard title="Itinerary" className="bg-[var(--card)] border-[var(--border)]">
-      <div className="min-w-0 flex flex-col gap-0 md:flex-row md:items-stretch md:gap-0 md:overflow-x-auto pb-2">
-        {segments.map((segment, i) => {
-          const next = segments[i + 1];
-          // Duration badge shown on connector between same-booking start→end pair
-          const connectorDuration =
-            next?.bookingId === segment.bookingId && next?.isEndSegment ? next.durationBadge : null;
-          return (
-            <div key={segment.segmentId} className="contents">
-              <SegmentCard segment={segment} />
-              {i < segments.length - 1 && (
-                <Connector dim={segment.isPast && next?.isPast} durationBadge={connectorDuration} />
-              )}
-            </div>
-          );
-        })}
+    <Card className="!p-0 overflow-hidden">
+      <TravelSectionHeader title="Itinerary" />
+      <div className="p-4">
+        <div className="min-w-0 flex flex-col gap-0 md:flex-row md:items-stretch md:gap-0 md:overflow-x-auto pb-2">
+          {segments.map((segment, i) => {
+            const next = segments[i + 1];
+            // Duration badge shown on connector between same-booking start→end pair
+            const connectorDuration =
+              next?.bookingId === segment.bookingId && next?.isEndSegment ? next.durationBadge : null;
+            return (
+              <div key={segment.segmentId} className="contents">
+                <SegmentCard segment={segment} />
+                {i < segments.length - 1 && (
+                  <Connector dim={segment.isPast && next?.isPast} durationBadge={connectorDuration} />
+                )}
+              </div>
+            );
+          })}
+        </div>
       </div>
-    </SectionCard>
+    </Card>
   );
 }

--- a/packages/hub/src/app/travel/CompanionsSection.tsx
+++ b/packages/hub/src/app/travel/CompanionsSection.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useState } from 'react';
-import { SectionCard } from '@/components/SectionCard';
+import { Card } from '@/components';
+import { TravelSectionHeader } from './ui';
 import type { TripCompanion } from '@my-hub/shared/types';
 import { Button, ConfirmModal, SwipeRow } from '@/components';
 import { PencilIcon, TrashOutlineIcon } from '@/components/icons';
@@ -62,8 +63,9 @@ export function CompanionsSection({ activeTripId, canEdit, companions, onChanged
         />
       )}
 
-      <SectionCard title="Companions" className="bg-[var(--card)] border-[var(--border)]" action={headerAction}>
-        <div className="max-h-64 space-y-1.5 overflow-auto">
+      <Card className="!p-0 overflow-hidden">
+        <TravelSectionHeader title="Companions" action={headerAction} />
+        <div className="max-h-64 space-y-1.5 overflow-auto p-4">
           {companions.map(companion => (
             <div key={companion.id} className="overflow-hidden rounded-md border border-[var(--border)]">
               {/* Mobile: swipe-to-reveal */}
@@ -120,7 +122,7 @@ export function CompanionsSection({ activeTripId, canEdit, companions, onChanged
           ))}
           {companions.length === 0 && <p className="text-sm text-[var(--muted)]">No companions yet.</p>}
         </div>
-      </SectionCard>
+      </Card>
     </>
   );
 }

--- a/packages/hub/src/app/travel/DayByDay.tsx
+++ b/packages/hub/src/app/travel/DayByDay.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useState } from 'react';
-import { SectionCard } from '@/components/SectionCard';
+import { Card } from '@/components';
+import { TravelSectionHeader } from './ui';
 import { BookingTypeIcon, Button, MarkdownView } from '@/components';
 import { PinIcon } from '@/components/icons';
 import type { TripPlace, TripWithStatus } from '@my-hub/shared/types';
@@ -138,8 +139,9 @@ export function DayByDay({ trip, bookings, dayNotes, places, canEdit, onChanged 
   const placesById = new Map<number, TripPlace>(places.map(p => [p.id, p]));
 
   return (
-    <SectionCard title="Day by Day" className="bg-[var(--card)] border-[var(--border)]">
-      <div className="space-y-3">
+    <Card className="!p-0 overflow-hidden">
+      <TravelSectionHeader title="Day by Day" />
+      <div className="space-y-3 p-4">
         {days.map(dateStr => {
           const note = noteByDate.get(dateStr);
           const dayPlaces = (note?.placeIds ?? [])
@@ -159,6 +161,6 @@ export function DayByDay({ trip, bookings, dayNotes, places, canEdit, onChanged 
           );
         })}
       </div>
-    </SectionCard>
+    </Card>
   );
 }

--- a/packages/hub/src/app/travel/DocumentsSection.tsx
+++ b/packages/hub/src/app/travel/DocumentsSection.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useState } from 'react';
-import { SectionCard } from '@/components/SectionCard';
+import { Card } from '@/components';
+import { TravelSectionHeader } from './ui';
 import type { TripDocument } from '@my-hub/shared/types';
 import type { TripBookingExtended } from './types';
 import { Button, ConfirmModal, IconButton } from '@/components';
@@ -58,8 +59,9 @@ export function DocumentsSection({ activeTripId, canEdit, documents, bookings, o
         />
       )}
 
-      <SectionCard title="Documents" className="bg-[var(--card)] border-[var(--border)]" action={headerAction}>
-        <div className="max-h-64 space-y-1.5 overflow-auto">
+      <Card className="!p-0 overflow-hidden">
+        <TravelSectionHeader title="Documents" action={headerAction} />
+        <div className="max-h-64 space-y-1.5 overflow-auto p-4">
           {documents.map(document => (
             <div
               key={document.id}
@@ -99,7 +101,7 @@ export function DocumentsSection({ activeTripId, canEdit, documents, bookings, o
           ))}
           {documents.length === 0 && <p className="text-sm text-[var(--muted)]">No documents yet.</p>}
         </div>
-      </SectionCard>
+      </Card>
     </>
   );
 }

--- a/packages/hub/src/app/travel/SharingSection.tsx
+++ b/packages/hub/src/app/travel/SharingSection.tsx
@@ -2,7 +2,8 @@
 
 import { useState } from 'react';
 import { Button } from '@/components';
-import { SectionCard } from '@/components/SectionCard';
+import { Card } from '@/components';
+import { TravelSectionHeader } from './ui';
 import type { ApiTrip, TripShareView } from './types';
 import { apiFetch } from '@/lib/utils';
 import { ShareModal } from './ShareModal';
@@ -58,29 +59,32 @@ export function SharingSection({ activeTrip, canEdit }: SharingSectionProps) {
         />
       )}
 
-      <SectionCard title="Sharing" className="bg-[var(--card)] border-[var(--border)]" action={headerAction}>
-        {!activeTrip && <p className="text-sm text-[var(--muted)]">Select a trip to manage sharing.</p>}
-        {activeTrip && !canEdit && (
-          <p className="text-sm text-[var(--muted)]">Only the trip owner can manage sharing.</p>
-        )}
-        {activeTrip && canEdit && (
-          <div className="space-y-1.5">
-            <p className="text-[9px] uppercase tracking-[0.07em] text-[var(--subtle)]">Shared with</p>
-            {shares.length === 0 && <p className="text-xs text-[var(--muted)]">Not shared with anyone yet.</p>}
-            {shares.map(share => (
-              <div
-                key={share.id}
-                className="flex items-center justify-between rounded-[10px] border border-[var(--border)] bg-[var(--card2)] px-3 py-2 text-xs"
-              >
-                <span className="text-[var(--text)]">{share.name ?? share.email}</span>
-                <Button variant="secondary" size="xs" onClick={() => revokeShare(share.id)}>
-                  Remove
-                </Button>
-              </div>
-            ))}
-          </div>
-        )}
-      </SectionCard>
+      <Card className="!p-0 overflow-hidden">
+        <TravelSectionHeader title="Sharing" action={headerAction} />
+        <div className="p-4">
+          {!activeTrip && <p className="text-sm text-[var(--muted)]">Select a trip to manage sharing.</p>}
+          {activeTrip && !canEdit && (
+            <p className="text-sm text-[var(--muted)]">Only the trip owner can manage sharing.</p>
+          )}
+          {activeTrip && canEdit && (
+            <div className="space-y-1.5">
+              <p className="text-[9px] uppercase tracking-[0.07em] text-[var(--subtle)]">Shared with</p>
+              {shares.length === 0 && <p className="text-xs text-[var(--muted)]">Not shared with anyone yet.</p>}
+              {shares.map(share => (
+                <div
+                  key={share.id}
+                  className="flex items-center justify-between rounded-[10px] border border-[var(--border)] bg-[var(--card2)] px-3 py-2 text-xs"
+                >
+                  <span className="text-[var(--text)]">{share.name ?? share.email}</span>
+                  <Button variant="secondary" size="xs" onClick={() => revokeShare(share.id)}>
+                    Remove
+                  </Button>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </Card>
     </>
   );
 }

--- a/packages/hub/src/app/travel/TripMap.tsx
+++ b/packages/hub/src/app/travel/TripMap.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import dynamic from 'next/dynamic';
-import { SectionCard } from '@/components/SectionCard';
+import { Card } from '@/components';
+import { TravelSectionHeader } from './ui';
 import type { TripMapData } from '@my-hub/shared/services';
 
 export type TripMapProps = {
@@ -21,17 +22,19 @@ const TripMapInner = dynamic(() => import('./TripMapInner').then(m => ({ default
 export function TripMap({ mapData }: TripMapProps) {
   if (mapData.points.length < 2) {
     return (
-      <SectionCard title="Map" className="bg-[var(--card)] border-[var(--border)]">
-        <p className="text-sm text-[var(--muted)]">
+      <Card className="!p-0 overflow-hidden">
+        <TravelSectionHeader title="Map" />
+        <p className="px-4 py-4 text-sm text-[var(--muted)]">
           No location data yet. Bookings with IATA codes or place coordinates will appear here.
         </p>
-      </SectionCard>
+      </Card>
     );
   }
 
   return (
-    <SectionCard title="Map" className="!p-0 overflow-hidden bg-[var(--card)] border-[var(--border)]">
+    <Card className="!p-0 overflow-hidden">
+      <TravelSectionHeader title="Map" />
       <TripMapInner mapData={mapData} />
-    </SectionCard>
+    </Card>
   );
 }

--- a/packages/hub/src/app/travel/TripOverviewCards.tsx
+++ b/packages/hub/src/app/travel/TripOverviewCards.tsx
@@ -1,6 +1,7 @@
-import { SectionCard } from '@/components/SectionCard';
+import { Card } from '@/components';
 import type { TripWithStatus } from '@my-hub/shared/types';
 import type { TripOverviewResponse } from './types';
+import { TravelSectionHeader } from './ui';
 
 function StatRow({ label, value }: { label: string; value: number }) {
   return (
@@ -19,21 +20,21 @@ type TripOverviewCardsProps = {
 
 export function TripOverviewCards({ activeTrip, overview, loadingOverview }: TripOverviewCardsProps) {
   return (
-    <SectionCard
-      title={activeTrip ? `${activeTrip.name} Overview` : 'Overview'}
-      className="bg-[var(--card)] border-[var(--border)]"
-    >
-      {!activeTrip && <p className="text-sm text-[var(--muted)]">Select a trip to view details.</p>}
-      {activeTrip && loadingOverview && <p className="text-sm text-[var(--muted)]">Loading…</p>}
-      {activeTrip && overview && (
-        <div className="divide-y divide-[var(--border)]">
-          <StatRow label="Reservations" value={overview.bookings.length} />
-          <StatRow label="Checklist" value={overview.checklist.length} />
-          <StatRow label="Companions" value={overview.companions.length} />
-          <StatRow label="Places" value={overview.places.length} />
-          <StatRow label="Documents" value={overview.documents.length} />
-        </div>
-      )}
-    </SectionCard>
+    <Card className="!p-0 overflow-hidden">
+      <TravelSectionHeader title={activeTrip ? `${activeTrip.name} Overview` : 'Overview'} />
+      <div className="p-4">
+        {!activeTrip && <p className="text-sm text-[var(--muted)]">Select a trip to view details.</p>}
+        {activeTrip && loadingOverview && <p className="text-sm text-[var(--muted)]">Loading…</p>}
+        {activeTrip && overview && (
+          <div className="divide-y divide-[var(--border)]">
+            <StatRow label="Reservations" value={overview.bookings.length} />
+            <StatRow label="Checklist" value={overview.checklist.length} />
+            <StatRow label="Companions" value={overview.companions.length} />
+            <StatRow label="Places" value={overview.places.length} />
+            <StatRow label="Documents" value={overview.documents.length} />
+          </div>
+        )}
+      </div>
+    </Card>
   );
 }

--- a/packages/hub/src/app/travel/calendar/page.tsx
+++ b/packages/hub/src/app/travel/calendar/page.tsx
@@ -2,7 +2,8 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import { apiFetch } from '@/lib/utils';
-import { SectionCard } from '@/components/SectionCard';
+import { Card } from '@/components';
+import { TravelSectionHeader } from '../ui';
 import type { TripOverviewResponse } from '../types';
 import { travelEvents } from '../travelEvents';
 import { readActiveTripId } from '../TripSwitcher';
@@ -39,9 +40,12 @@ export default function TravelCalendarPage() {
       {!activeTripId ? (
         <p className="text-sm text-[var(--muted)]">Select a trip to view the calendar.</p>
       ) : overview ? (
-        <SectionCard title="Calendar" className="bg-[var(--card)] border-[var(--border)]">
-          <BookingsCalendar bookings={overview.bookings} tripColor={overview.trip.color} trip={overview.trip} />
-        </SectionCard>
+        <Card className="!p-0 overflow-hidden">
+          <TravelSectionHeader title="Calendar" />
+          <div className="p-4">
+            <BookingsCalendar bookings={overview.bookings} tripColor={overview.trip.color} trip={overview.trip} />
+          </div>
+        </Card>
       ) : null}
     </main>
   );

--- a/packages/hub/src/app/travel/more/page.tsx
+++ b/packages/hub/src/app/travel/more/page.tsx
@@ -2,7 +2,8 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { apiFetch } from '@/lib/utils';
-import { SectionCard } from '@/components/SectionCard';
+import { Card } from '@/components';
+import { TravelSectionHeader } from '../ui';
 import type { TripOverviewResponse, ApiTrip } from '../types';
 import { travelEvents } from '../travelEvents';
 import { readActiveTripId } from '../TripSwitcher';
@@ -51,9 +52,12 @@ export default function TravelMorePage() {
           {overview && (
             <>
               <TripMap mapData={overview.mapData} tripId={activeTripId} />
-              <SectionCard title="Calendar" className="bg-[var(--card)] border-[var(--border)]">
-                <BookingsCalendar bookings={overview.bookings} tripColor={overview.trip.color} trip={overview.trip} />
-              </SectionCard>
+              <Card className="!p-0 overflow-hidden">
+                <TravelSectionHeader title="Calendar" />
+                <div className="p-4">
+                  <BookingsCalendar bookings={overview.bookings} tripColor={overview.trip.color} trip={overview.trip} />
+                </div>
+              </Card>
             </>
           )}
           <CompanionsSection

--- a/packages/hub/src/app/travel/ui.tsx
+++ b/packages/hub/src/app/travel/ui.tsx
@@ -2,6 +2,15 @@ import type React from 'react';
 import { TripBookingTypes } from '@my-hub/shared/constants';
 import type { TripBookingType } from '@my-hub/shared/types';
 
+export function TravelSectionHeader({ title, action }: { title: string; action?: React.ReactNode }) {
+  return (
+    <div className="flex items-center justify-between border-b border-[var(--border)] px-4 py-3">
+      <h2 className="text-sm font-semibold text-[var(--text)]">{title}</h2>
+      {action && <div>{action}</div>}
+    </div>
+  );
+}
+
 export const bookingTypeLabels: Record<TripBookingType, string> = {
   [TripBookingTypes.Flight]: 'Flight',
   [TripBookingTypes.Accommodation]: 'Accommodation',

--- a/packages/hub/src/components/Modal.tsx
+++ b/packages/hub/src/components/Modal.tsx
@@ -51,6 +51,31 @@ export function Modal({
     };
   }, []);
 
+  // On iOS, when the virtual keyboard opens the browser scrolls window to
+  // bring the focused input into view, which displaces fixed-position elements.
+  // Pinning the modal shell to the visualViewport dimensions corrects this.
+  useEffect(() => {
+    const vv = window.visualViewport;
+    const el = containerRef.current;
+    if (!vv || !el) return;
+
+    const sync = () => {
+      if (window.innerWidth >= 768) return; // desktop modal handles itself
+      el.style.top = `${vv.offsetTop}px`;
+      el.style.height = `${vv.height}px`;
+    };
+
+    sync();
+    vv.addEventListener('resize', sync);
+    vv.addEventListener('scroll', sync);
+    return () => {
+      el.style.top = '';
+      el.style.height = '';
+      vv.removeEventListener('resize', sync);
+      vv.removeEventListener('scroll', sync);
+    };
+  }, []);
+
   useEffect(() => {
     const el = containerRef.current;
     if (!el) return;

--- a/packages/hub/src/styles/globals.css
+++ b/packages/hub/src/styles/globals.css
@@ -72,7 +72,10 @@
 /* Prevent iOS/Android auto-zoom on input focus (requires font-size >= 16px) */
 @media (max-width: 767px) {
   .finances-theme input,
-  .finances-theme textarea {
+  .finances-theme textarea,
+  .modal-shell input,
+  .modal-shell textarea,
+  .modal-shell select {
     font-size: 16px;
   }
 }


### PR DESCRIPTION
Travel sections now use the same full-bleed Card component as calories screens,
giving a better mobile appearance. Adds TravelSectionHeader for section titles.

Modal keyboard fixes: visualViewport API pins the modal shell to the visible
viewport on iOS (prevents keyboard from displacing the modal), font-size:16px
on modal inputs prevents iOS auto-zoom, and interactiveWidget=resizes-visual
viewport config prevents keyboard from resizing the layout viewport on Chrome.

https://claude.ai/code/session_01EReBbzjo1oyqPJVy7FtYug