### PR TITLE
fix: restore background on mobile dropdown list scroll container

### DIFF
--- a/packages/hub/src/components/MobileSelectSheet.tsx
+++ b/packages/hub/src/components/MobileSelectSheet.tsx
@@ -184,7 +184,7 @@ export function MobileSelectSheet({
           </div>
         )}
 
-        <div ref={listRef} className="overflow-y-auto">
+        <div ref={listRef} className="overflow-y-auto bg-[var(--card)]">
           {results.map(item => (
             <Button
               key={item.id}


### PR DESCRIPTION
The overflow-y-auto list div in MobileSelectSheet had no background-color,
causing mobile browsers to composite it as a transparent layer and show the
modal content behind the dropdown options.