### PR TITLE
Align reporting spending trend with dashboard and fix double-negative Net sign

### DIFF
--- a/docs/requirements/hub/feature-finances.md
+++ b/docs/requirements/hub/feature-finances.md
@@ -110,3 +110,5 @@ finances layout with sidebar navigation on desktop and bottom-tab navigation on 
 - [x] Clicking a category opens a dedicated category details screen with summary details on top and transactions listed below.
 - [x] Category details transactions are shown ordered by date descending (with id tie-breaker descending).
 - [x] Dashboard budget categories are shown in descending order by amount spent.
+- [x] The Reporting page's Spending Trend chart includes categorized transfers (e.g. loan repayments) in its daily totals, matching the Dashboard "Spending" chart.
+- [x] The Reporting "Net" summary card renders a single leading sign (`-`/`+`) for negative/positive values, without doubling the currency formatter's own minus sign.

--- a/packages/hub/src/app/api/finances/reporting/route.ts
+++ b/packages/hub/src/app/api/finances/reporting/route.ts
@@ -138,46 +138,71 @@ export const GET = route({ query: QuerySchema, response: reportingResponseSchema
   const breakdownType = query.type === TransactionTypes.Income ? TransactionTypes.Income : TransactionTypes.Expense;
   const summaryType = query.type; // undefined = fetch both
 
+  // Categorized transfers (e.g. loan repayments) are counted as spending on the dashboard,
+  // so the spending trend needs them too for the two charts to agree.
+  const includeTransfers = query.dateMode === 'month' && breakdownType === TransactionTypes.Expense;
+
   // Fetch all needed transactions in parallel
-  const [breakdownTxns, prevBreakdownTxns, incomeTxns, prevIncomeTxns] = await Promise.all([
-    // Current period breakdown transactions (expense or income based on filter)
-    getTransactionListItems(user.id, budgetId, {
-      ...filterOpts,
-      type: summaryType ?? breakdownType,
-      fromDate,
-      toDate,
-    }),
-    // Previous period breakdown transactions
-    prevFromDate && prevToDate
-      ? getTransactions(user.id, budgetId, {
-          ...filterOpts,
-          type: summaryType ?? breakdownType,
-          fromDate: prevFromDate,
-          toDate: prevToDate,
-          limit: 5000,
-        })
-      : Promise.resolve([]),
-    // Income for summary context (only when no type filter or expense filter)
-    !summaryType || summaryType === TransactionTypes.Expense
-      ? getTransactions(user.id, budgetId, {
-          ...filterOpts,
-          type: TransactionTypes.Income,
-          fromDate,
-          toDate,
-          limit: 5000,
-        })
-      : Promise.resolve([]),
-    // Previous income for comparison
-    prevFromDate && prevToDate && (!summaryType || summaryType === TransactionTypes.Expense)
-      ? getTransactions(user.id, budgetId, {
-          ...filterOpts,
-          type: TransactionTypes.Income,
-          fromDate: prevFromDate,
-          toDate: prevToDate,
-          limit: 5000,
-        })
-      : Promise.resolve([]),
-  ]);
+  const [breakdownTxns, prevBreakdownTxns, incomeTxns, prevIncomeTxns, transferTxns, prevTransferTxns] =
+    await Promise.all([
+      // Current period breakdown transactions (expense or income based on filter)
+      getTransactionListItems(user.id, budgetId, {
+        ...filterOpts,
+        type: summaryType ?? breakdownType,
+        fromDate,
+        toDate,
+      }),
+      // Previous period breakdown transactions
+      prevFromDate && prevToDate
+        ? getTransactions(user.id, budgetId, {
+            ...filterOpts,
+            type: summaryType ?? breakdownType,
+            fromDate: prevFromDate,
+            toDate: prevToDate,
+            limit: 5000,
+          })
+        : Promise.resolve([]),
+      // Income for summary context (only when no type filter or expense filter)
+      !summaryType || summaryType === TransactionTypes.Expense
+        ? getTransactions(user.id, budgetId, {
+            ...filterOpts,
+            type: TransactionTypes.Income,
+            fromDate,
+            toDate,
+            limit: 5000,
+          })
+        : Promise.resolve([]),
+      // Previous income for comparison
+      prevFromDate && prevToDate && (!summaryType || summaryType === TransactionTypes.Expense)
+        ? getTransactions(user.id, budgetId, {
+            ...filterOpts,
+            type: TransactionTypes.Income,
+            fromDate: prevFromDate,
+            toDate: prevToDate,
+            limit: 5000,
+          })
+        : Promise.resolve([]),
+      // Categorized transfers for the current period (counted as spending, like the dashboard)
+      includeTransfers
+        ? getTransactions(user.id, budgetId, {
+            ...filterOpts,
+            type: TransactionTypes.Transfer,
+            fromDate,
+            toDate,
+            limit: 5000,
+          })
+        : Promise.resolve([]),
+      // Categorized transfers for the previous period
+      includeTransfers && prevFromDate && prevToDate
+        ? getTransactions(user.id, budgetId, {
+            ...filterOpts,
+            type: TransactionTypes.Transfer,
+            fromDate: prevFromDate,
+            toDate: prevToDate,
+            limit: 5000,
+          })
+        : Promise.resolve([]),
+    ]);
 
   // Compute totals
   const expenseTxns =
@@ -293,10 +318,22 @@ export const GET = route({ query: QuerySchema, response: reportingResponseSchema
       const day = +t.date.slice(8, 10);
       currentDayMap.set(day, (currentDayMap.get(day) ?? 0) + t.amount);
     }
+    for (const t of transferTxns) {
+      if (t.categoryId != null) {
+        const day = +t.date.slice(8, 10);
+        currentDayMap.set(day, (currentDayMap.get(day) ?? 0) + t.amount);
+      }
+    }
     const prevDayMap = new Map<number, number>();
     for (const t of prevBreakdownTxns) {
       const day = +t.date.slice(8, 10);
       prevDayMap.set(day, (prevDayMap.get(day) ?? 0) + t.amount);
+    }
+    for (const t of prevTransferTxns) {
+      if (t.categoryId != null) {
+        const day = +t.date.slice(8, 10);
+        prevDayMap.set(day, (prevDayMap.get(day) ?? 0) + t.amount);
+      }
     }
 
     let currentCumulative = 0;

--- a/packages/hub/src/app/finances/ui.tsx
+++ b/packages/hub/src/app/finances/ui.tsx
@@ -27,7 +27,7 @@ export function fmt(value: number, currency = 'EUR', reverseSign = false) {
 }
 
 export function fmtSign(value: number, currency = 'EUR') {
-  return (value < 0 ? '-' : '+') + fmt(value, currency);
+  return (value < 0 ? '-' : '+') + fmt(Math.abs(value), currency);
 }
 
 // ─── Primitive components ─────────────────────────────────────────────────────


### PR DESCRIPTION
Reporting's Spending Trend chart now includes categorized transfers
(e.g. loan repayments) in its daily totals, matching the Dashboard
"Spending" chart. Also fixes fmtSign rendering "--" for negative
amounts since the currency formatter already adds its own minus sign.

https://claude.ai/code/session_01XuRqYqMRsFEfErdbdyr4qF