### PR TITLE
fix: clearing transaction memo or payee in edit modal had no effect

### DIFF
--- a/packages/hub/src/app/finances/transactions/TransactionModal/index.tsx
+++ b/packages/hub/src/app/finances/transactions/TransactionModal/index.tsx
@@ -170,8 +170,8 @@ export function TransactionModal({
       amount: parseFloat(values.amount),
       date: values.date,
       categoryId: selCatId,
-      payeeName: values.payee.trim() || undefined,
-      notes: values.note.trim() || undefined,
+      payeeName: values.payee.trim(),
+      notes: values.note.trim(),
       labels: values.labels,
     };
 


### PR DESCRIPTION
`|| undefined` caused empty strings to be omitted from the PATCH body,
which the API interprets as "don't change this field". Both notes and
payeeName are now always sent as trimmed strings so the API can convert
empty → null and clear the field in the DB.

https://claude.ai/code/session_01AxezEMEMWb2inQwH3bW3Wr