### PR TITLE
Fix stale "Now" badge on itinerary segments; make Day by Day collapsible

### DIFF
--- a/packages/hub/src/app/finances/accounts/page.tsx
+++ b/packages/hub/src/app/finances/accounts/page.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import { cn, apiFetch } from '@/lib/utils';
 import { fmt, AddButton, TYPE_META } from '../ui';
-import { Card, Divider, IconButton, SectionLabel, Sparkline, SubText } from '@/components';
+import { Card, Collapsible, Divider, IconButton, Sparkline, SubText } from '@/components';
 import { QuestionMarkIcon } from '@/components/icons';
 import { AccountModal } from './AccountModal';
 import { AccountProgressBar } from './AccountProgressBar';
@@ -181,78 +181,31 @@ export default function AccountsPage() {
         const isCollapsed = collapsedGroups.has(key);
         const groupedAccounts = groupAccountsByCurrency(accs);
         return (
-          <div key={key}>
-            <button
-              onClick={() => toggleGroup(key)}
-              className="mb-1 flex w-full cursor-pointer items-center justify-between"
-            >
-              <SectionLabel className="mb-0">
+          <Collapsible
+            key={key}
+            variant="text"
+            label={
+              <>
                 {icon} {label}
-              </SectionLabel>
-              <div className="flex items-center gap-1.5">
-                <span className="text-[11px] font-semibold tabular-nums text-[var(--muted)]">
-                  {groupedAccounts.map(([currency, accounts]) => {
-                    const groupTotal = accounts.reduce((sum, acc) => sum + acc.balance, 0);
-                    return (
-                      <span key={currency} className="ml-2">
-                        {fmt(groupTotal, currency)}
-                      </span>
-                    );
-                  })}
-                </span>
-                <span
-                  className={cn(
-                    'text-[9px] text-[var(--subtle)] transition-transform duration-200',
-                    !isCollapsed && 'rotate-90',
-                  )}
-                >
-                  ▶
-                </span>
-              </div>
-            </button>
-            {!isCollapsed && (
-              <Card className="p-0">
-                {accs.map((acc, i) => (
-                  <div key={acc.id}>
-                    {i > 0 && <Divider />}
-                    <AccountCard
-                      acc={acc}
-                      onSettle={handleSettle}
-                      onClick={() => router.push(`/finances/accounts/${acc.id}`)}
-                    />
-                  </div>
-                ))}
-              </Card>
-            )}
-          </div>
-        );
-      })}
-
-      {activeAccounts.length === 0 && archivedAccounts.length === 0 && (
-        <div className="py-12 text-center text-[13px] text-[var(--subtle)]">
-          No accounts yet. Add your first account to get started.
-        </div>
-      )}
-
-      {archivedAccounts.length > 0 && (
-        <div>
-          <button
-            onClick={() => setShowArchived(v => !v)}
-            className="mb-1 flex w-full cursor-pointer items-center justify-between"
+              </>
+            }
+            open={!isCollapsed}
+            onOpenChange={() => toggleGroup(key)}
+            actions={
+              <span className="text-[11px] font-semibold tabular-nums text-[var(--muted)]">
+                {groupedAccounts.map(([currency, accounts]) => {
+                  const groupTotal = accounts.reduce((sum, acc) => sum + acc.balance, 0);
+                  return (
+                    <span key={currency} className="ml-2">
+                      {fmt(groupTotal, currency)}
+                    </span>
+                  );
+                })}
+              </span>
+            }
           >
-            <SectionLabel className="mb-0">🗄 Archived ({archivedAccounts.length})</SectionLabel>
-            <span
-              className={cn(
-                'text-[9px] text-[var(--subtle)] transition-transform duration-200',
-                showArchived && 'rotate-90',
-              )}
-            >
-              ▶
-            </span>
-          </button>
-          {showArchived && (
             <Card className="p-0">
-              {archivedAccounts.map((acc, i) => (
+              {accs.map((acc, i) => (
                 <div key={acc.id}>
                   {i > 0 && <Divider />}
                   <AccountCard
@@ -263,8 +216,36 @@ export default function AccountsPage() {
                 </div>
               ))}
             </Card>
-          )}
+          </Collapsible>
+        );
+      })}
+
+      {activeAccounts.length === 0 && archivedAccounts.length === 0 && (
+        <div className="py-12 text-center text-[13px] text-[var(--subtle)]">
+          No accounts yet. Add your first account to get started.
         </div>
+      )}
+
+      {archivedAccounts.length > 0 && (
+        <Collapsible
+          variant="text"
+          label={`🗄 Archived (${archivedAccounts.length})`}
+          open={showArchived}
+          onOpenChange={setShowArchived}
+        >
+          <Card className="p-0">
+            {archivedAccounts.map((acc, i) => (
+              <div key={acc.id}>
+                {i > 0 && <Divider />}
+                <AccountCard
+                  acc={acc}
+                  onSettle={handleSettle}
+                  onClick={() => router.push(`/finances/accounts/${acc.id}`)}
+                />
+              </div>
+            ))}
+          </Card>
+        </Collapsible>
       )}
 
       {showAddModal && (

--- a/packages/hub/src/app/finances/accounts/page.tsx
+++ b/packages/hub/src/app/finances/accounts/page.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import { cn, apiFetch } from '@/lib/utils';
 import { fmt, AddButton, TYPE_META } from '../ui';
-import { Card, Collapsible, Divider, IconButton, Sparkline, SubText } from '@/components';
+import { Card, Collapsible, Divider, IconButton, SectionLabel, Sparkline, SubText } from '@/components';
 import { QuestionMarkIcon } from '@/components/icons';
 import { AccountModal } from './AccountModal';
 import { AccountProgressBar } from './AccountProgressBar';
@@ -185,9 +185,9 @@ export default function AccountsPage() {
             key={key}
             variant="text"
             label={
-              <>
+              <SectionLabel className="mb-0">
                 {icon} {label}
-              </>
+              </SectionLabel>
             }
             open={!isCollapsed}
             onOpenChange={() => toggleGroup(key)}
@@ -229,9 +229,9 @@ export default function AccountsPage() {
       {archivedAccounts.length > 0 && (
         <Collapsible
           variant="text"
-          label={`🗄 Archived (${archivedAccounts.length})`}
+          label={<SectionLabel className="mb-0">🗄 Archived ({archivedAccounts.length})</SectionLabel>}
           open={showArchived}
-          onOpenChange={setShowArchived}
+          onOpenChange={() => setShowArchived(v => !v)}
         >
           <Card className="p-0">
             {archivedAccounts.map((acc, i) => (

--- a/packages/hub/src/app/finances/categories/GroupSection.tsx
+++ b/packages/hub/src/app/finances/categories/GroupSection.tsx
@@ -6,7 +6,7 @@ import { PencilIcon, TrashOutlineIcon } from '@/components/icons';
 import { fmt } from '../ui';
 import { CatRow } from './CatRow';
 import type { CategoryGroup, CategoryRow } from '@/app/api/finances/categories/route';
-import { SubText, Card, Divider } from '@/components';
+import { SubText, Card, Collapsible, Divider } from '@/components';
 
 type GroupSectionProps = {
   group: CategoryGroup;
@@ -48,35 +48,33 @@ export function GroupSection({
   }
 
   return (
-    <div>
-      <div className="group/header mb-1.5 flex items-center justify-between px-1 py-[6px]">
-        <div className="flex min-w-0 flex-1 items-center gap-2">
-          <div className="h-2.5 w-2.5 shrink-0 rounded-[3px]" style={{ background: color }} />
+    <Collapsible
+      variant="text"
+      label={group.name}
+      open={!collapsed}
+      onOpenChange={open => setCollapsed(!open)}
+      headerClassName="group/header px-1 py-[6px]"
+      leading={<div className="h-2.5 w-2.5 shrink-0 rounded-[3px]" style={{ background: color }} />}
+      inlineActions={
+        // Always visible on mobile, hover-only on desktop
+        <div className="flex items-center gap-0.5 transition-opacity md:opacity-0 md:group-hover/header:opacity-100">
           <button
-            onClick={() => setCollapsed(v => !v)}
-            className="flex cursor-pointer items-center gap-1 border-none bg-transparent p-0"
+            aria-label={`Edit group ${group.name}`}
+            onClick={() => onEditGroup(group)}
+            className="cursor-pointer rounded p-0.5 text-[var(--subtle)] hover:bg-[var(--card2)] hover:text-[var(--text)]"
           >
-            <span className="text-[13px] font-semibold text-[var(--text)]">{group.name}</span>
-            <SubText>{collapsed ? '▶' : '▾'}</SubText>
+            <PencilIcon className="size-[11px]" />
           </button>
-          {/* Always visible on mobile, hover-only on desktop */}
-          <div className="flex items-center gap-0.5 transition-opacity md:opacity-0 md:group-hover/header:opacity-100">
-            <button
-              aria-label={`Edit group ${group.name}`}
-              onClick={() => onEditGroup(group)}
-              className="cursor-pointer rounded p-0.5 text-[var(--subtle)] hover:bg-[var(--card2)] hover:text-[var(--text)]"
-            >
-              <PencilIcon className="size-[11px]" />
-            </button>
-            <button
-              aria-label={`Delete group ${group.name}`}
-              onClick={deleteGroup}
-              className="cursor-pointer rounded p-0.5 text-[var(--subtle)] hover:bg-[var(--card2)] hover:text-red-400"
-            >
-              <TrashOutlineIcon className="size-[11px]" />
-            </button>
-          </div>
+          <button
+            aria-label={`Delete group ${group.name}`}
+            onClick={deleteGroup}
+            className="cursor-pointer rounded p-0.5 text-[var(--subtle)] hover:bg-[var(--card2)] hover:text-red-400"
+          >
+            <TrashOutlineIcon className="size-[11px]" />
+          </button>
         </div>
+      }
+      actions={
         <div className="flex items-center gap-2">
           {groupTarget > 0 && (
             <SubText>
@@ -92,36 +90,35 @@ export function GroupSection({
             </span>
           )}
         </div>
-      </div>
-      {!collapsed && (
-        <Card className="py-[6px]">
-          {group.categories.map((cat, i) => (
-            <div key={cat.id}>
-              {i > 0 && <Divider />}
-              <CatRow
-                cat={cat}
-                currency={currency}
-                isSwipeOpen={openSwipeId === cat.id}
-                onSwipeOpen={() => setOpenSwipeId(cat.id)}
-                onSwipeClose={() => setOpenSwipeId(null)}
-                onEdit={onEditCategory}
-                onDelete={onDeleteCategory}
-                onOpen={onOpenCategory}
-              />
-            </div>
-          ))}
-          {group.categories.length === 0 && (
-            <div className="p-[14px] text-center text-xs text-[var(--subtle)]">No categories in this group</div>
-          )}
-          {group.categories.length > 0 && <Divider />}
-          <button
-            onClick={() => onAddCategory(group.id)}
-            className="w-full cursor-pointer border-none bg-transparent px-[14px] py-[10px] text-left text-[12px] text-[var(--subtle)] hover:text-[var(--text)]"
-          >
-            + Add category
-          </button>
-        </Card>
-      )}
-    </div>
+      }
+    >
+      <Card className="py-[6px]">
+        {group.categories.map((cat, i) => (
+          <div key={cat.id}>
+            {i > 0 && <Divider />}
+            <CatRow
+              cat={cat}
+              currency={currency}
+              isSwipeOpen={openSwipeId === cat.id}
+              onSwipeOpen={() => setOpenSwipeId(cat.id)}
+              onSwipeClose={() => setOpenSwipeId(null)}
+              onEdit={onEditCategory}
+              onDelete={onDeleteCategory}
+              onOpen={onOpenCategory}
+            />
+          </div>
+        ))}
+        {group.categories.length === 0 && (
+          <div className="p-[14px] text-center text-xs text-[var(--subtle)]">No categories in this group</div>
+        )}
+        {group.categories.length > 0 && <Divider />}
+        <button
+          onClick={() => onAddCategory(group.id)}
+          className="w-full cursor-pointer border-none bg-transparent px-[14px] py-[10px] text-left text-[12px] text-[var(--subtle)] hover:text-[var(--text)]"
+        >
+          + Add category
+        </button>
+      </Card>
+    </Collapsible>
   );
 }

--- a/packages/hub/src/app/travel/DayByDay.tsx
+++ b/packages/hub/src/app/travel/DayByDay.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import { Card } from '@/components';
 import { TravelSectionHeader } from './ui';
 import { BookingTypeIcon, Button, MarkdownView } from '@/components';
-import { PinIcon } from '@/components/icons';
+import { ChevronDownOutlineIcon, ChevronRightOutlineIcon, PinIcon } from '@/components/icons';
 import type { TripPlace, TripWithStatus } from '@my-hub/shared/types';
 import type { TripBookingExtended, TripDay } from './types';
 import { calendarDays, formatDayHeading, toUTCDateStr } from '@my-hub/shared/utils';
@@ -38,8 +38,11 @@ type DayCardProps = {
 
 function DayCard({ dateStr, note, bookings, dayPlaces, canEdit, tripId, onChanged }: DayCardProps) {
   const [showModal, setShowModal] = useState(false);
+  const isPastDay = dateStr < toUTCDateStr(new Date());
+  const [isExpanded, setIsExpanded] = useState(!isPastDay);
 
   const dayBookings = bookings.filter(b => b.startAt && toUTCDateStr(new Date(b.startAt)) === dateStr);
+  const ChevronIcon = isExpanded ? ChevronDownOutlineIcon : ChevronRightOutlineIcon;
 
   async function handleSave(title: string, notes: string) {
     await apiFetch(`/api/travel/trips/${tripId}/days`, {
@@ -69,8 +72,16 @@ function DayCard({ dateStr, note, bookings, dayPlaces, canEdit, tripId, onChange
 
       <div className="space-y-3 rounded-lg border border-[var(--border)] bg-[var(--card)] p-4">
         <div className="flex items-center justify-between gap-2">
-          <h3 className="text-sm font-semibold text-[var(--text)]">{formatDayHeading(dateStr)}</h3>
-          {canEdit && (
+          <button
+            type="button"
+            onClick={() => setIsExpanded(v => !v)}
+            aria-expanded={isExpanded}
+            className="flex items-center gap-1.5 text-sm font-semibold text-[var(--text)] hover:text-[var(--muted)]"
+          >
+            <ChevronIcon className="size-3.5 shrink-0 text-[var(--subtle)]" />
+            <span>{formatDayHeading(dateStr)}</span>
+          </button>
+          {canEdit && isExpanded && (
             <Button
               type="button"
               variant="ghost"
@@ -83,46 +94,52 @@ function DayCard({ dateStr, note, bookings, dayPlaces, canEdit, tripId, onChange
           )}
         </div>
 
-        {dayBookings.length > 0 && (
-          <ul className="space-y-1">
-            {dayBookings.map(b => (
-              <li key={b.id} className="flex items-center gap-2 text-xs text-[var(--muted)]">
-                <span className="shrink-0 text-[var(--subtle)]">
-                  <BookingTypeIcon type={b.bookingType} />
-                </span>
-                <span className="truncate">{b.title}</span>
-                {b.provider && <span className="shrink-0 text-[var(--subtle)]">· {b.provider}</span>}
-              </li>
-            ))}
-          </ul>
-        )}
-
-        {note ? (
-          <div className="space-y-1">
-            {note.title && <p className="text-sm font-medium text-[var(--text)]">{note.title}</p>}
-            {note.notes && <MarkdownView value={note.notes} className="text-xs leading-relaxed text-[var(--muted)]" />}
-            {dayPlaces.length > 0 && (
-              <div className="flex flex-wrap gap-1 pt-1">
-                {dayPlaces.map(place => (
-                  <a
-                    key={place.id}
-                    href={getPlaceMapUrl(place)}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    title={place.location ?? place.name}
-                    className="inline-flex min-w-0 max-w-full items-center gap-1 rounded-full border border-[var(--amber)]/60 bg-[var(--amber-d)] px-2 py-0.5 text-xs text-[var(--amber)] transition-colors hover:opacity-80"
-                  >
-                    <PinIcon />
-                    <span className="max-w-[10rem] truncate">{place.name}</span>
-                  </a>
+        {isExpanded && (
+          <>
+            {dayBookings.length > 0 && (
+              <ul className="space-y-1">
+                {dayBookings.map(b => (
+                  <li key={b.id} className="flex items-center gap-2 text-xs text-[var(--muted)]">
+                    <span className="shrink-0 text-[var(--subtle)]">
+                      <BookingTypeIcon type={b.bookingType} />
+                    </span>
+                    <span className="truncate">{b.title}</span>
+                    {b.provider && <span className="shrink-0 text-[var(--subtle)]">· {b.provider}</span>}
+                  </li>
                 ))}
-              </div>
+              </ul>
             )}
-          </div>
-        ) : (
-          dayBookings.length === 0 && (
-            <p className="text-xs italic text-[var(--subtle)]">No bookings or notes for this day.</p>
-          )
+
+            {note ? (
+              <div className="space-y-1">
+                {note.title && <p className="text-sm font-medium text-[var(--text)]">{note.title}</p>}
+                {note.notes && (
+                  <MarkdownView value={note.notes} className="text-xs leading-relaxed text-[var(--muted)]" />
+                )}
+                {dayPlaces.length > 0 && (
+                  <div className="flex flex-wrap gap-1 pt-1">
+                    {dayPlaces.map(place => (
+                      <a
+                        key={place.id}
+                        href={getPlaceMapUrl(place)}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        title={place.location ?? place.name}
+                        className="inline-flex min-w-0 max-w-full items-center gap-1 rounded-full border border-[var(--amber)]/60 bg-[var(--amber-d)] px-2 py-0.5 text-xs text-[var(--amber)] transition-colors hover:opacity-80"
+                      >
+                        <PinIcon />
+                        <span className="max-w-[10rem] truncate">{place.name}</span>
+                      </a>
+                    ))}
+                  </div>
+                )}
+              </div>
+            ) : (
+              dayBookings.length === 0 && (
+                <p className="text-xs italic text-[var(--subtle)]">No bookings or notes for this day.</p>
+              )
+            )}
+          </>
         )}
       </div>
     </>

--- a/packages/hub/src/app/travel/DayByDay.tsx
+++ b/packages/hub/src/app/travel/DayByDay.tsx
@@ -1,10 +1,10 @@
 'use client';
 
 import { useState } from 'react';
-import { Card } from '@/components';
+import { Card, Collapsible } from '@/components';
 import { TravelSectionHeader } from './ui';
 import { BookingTypeIcon, Button, MarkdownView } from '@/components';
-import { ChevronDownOutlineIcon, ChevronRightOutlineIcon, PinIcon } from '@/components/icons';
+import { PinIcon } from '@/components/icons';
 import type { TripPlace, TripWithStatus } from '@my-hub/shared/types';
 import type { TripBookingExtended, TripDay } from './types';
 import { calendarDays, formatDayHeading, toUTCDateStr } from '@my-hub/shared/utils';
@@ -42,7 +42,6 @@ function DayCard({ dateStr, note, bookings, dayPlaces, canEdit, tripId, onChange
   const [isExpanded, setIsExpanded] = useState(!isPastDay);
 
   const dayBookings = bookings.filter(b => b.startAt && toUTCDateStr(new Date(b.startAt)) === dateStr);
-  const ChevronIcon = isExpanded ? ChevronDownOutlineIcon : ChevronRightOutlineIcon;
 
   async function handleSave(title: string, notes: string) {
     await apiFetch(`/api/travel/trips/${tripId}/days`, {
@@ -70,18 +69,15 @@ function DayCard({ dateStr, note, bookings, dayPlaces, canEdit, tripId, onChange
         />
       )}
 
-      <div className="space-y-3 rounded-lg border border-[var(--border)] bg-[var(--card)] p-4">
-        <div className="flex items-center justify-between gap-2">
-          <button
-            type="button"
-            onClick={() => setIsExpanded(v => !v)}
-            aria-expanded={isExpanded}
-            className="flex items-center gap-1.5 text-sm font-semibold text-[var(--text)] hover:text-[var(--muted)]"
-          >
-            <ChevronIcon className="size-3.5 shrink-0 text-[var(--subtle)]" />
-            <span>{formatDayHeading(dateStr)}</span>
-          </button>
-          {canEdit && isExpanded && (
+      <Collapsible
+        variant="box"
+        label={formatDayHeading(dateStr)}
+        open={isExpanded}
+        onOpenChange={setIsExpanded}
+        contentClassName="space-y-3"
+        actions={
+          canEdit &&
+          isExpanded && (
             <Button
               type="button"
               variant="ghost"
@@ -91,57 +87,51 @@ function DayCard({ dateStr, note, bookings, dayPlaces, canEdit, tripId, onChange
             >
               {note ? 'Edit' : '+ Add notes'}
             </Button>
-          )}
-        </div>
-
-        {isExpanded && (
-          <>
-            {dayBookings.length > 0 && (
-              <ul className="space-y-1">
-                {dayBookings.map(b => (
-                  <li key={b.id} className="flex items-center gap-2 text-xs text-[var(--muted)]">
-                    <span className="shrink-0 text-[var(--subtle)]">
-                      <BookingTypeIcon type={b.bookingType} />
-                    </span>
-                    <span className="truncate">{b.title}</span>
-                    {b.provider && <span className="shrink-0 text-[var(--subtle)]">· {b.provider}</span>}
-                  </li>
-                ))}
-              </ul>
-            )}
-
-            {note ? (
-              <div className="space-y-1">
-                {note.title && <p className="text-sm font-medium text-[var(--text)]">{note.title}</p>}
-                {note.notes && (
-                  <MarkdownView value={note.notes} className="text-xs leading-relaxed text-[var(--muted)]" />
-                )}
-                {dayPlaces.length > 0 && (
-                  <div className="flex flex-wrap gap-1 pt-1">
-                    {dayPlaces.map(place => (
-                      <a
-                        key={place.id}
-                        href={getPlaceMapUrl(place)}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        title={place.location ?? place.name}
-                        className="inline-flex min-w-0 max-w-full items-center gap-1 rounded-full border border-[var(--amber)]/60 bg-[var(--amber-d)] px-2 py-0.5 text-xs text-[var(--amber)] transition-colors hover:opacity-80"
-                      >
-                        <PinIcon />
-                        <span className="max-w-[10rem] truncate">{place.name}</span>
-                      </a>
-                    ))}
-                  </div>
-                )}
-              </div>
-            ) : (
-              dayBookings.length === 0 && (
-                <p className="text-xs italic text-[var(--subtle)]">No bookings or notes for this day.</p>
-              )
-            )}
-          </>
+          )
+        }
+      >
+        {dayBookings.length > 0 && (
+          <ul className="space-y-1">
+            {dayBookings.map(b => (
+              <li key={b.id} className="flex items-center gap-2 text-xs text-[var(--muted)]">
+                <span className="shrink-0 text-[var(--subtle)]">
+                  <BookingTypeIcon type={b.bookingType} />
+                </span>
+                <span className="truncate">{b.title}</span>
+                {b.provider && <span className="shrink-0 text-[var(--subtle)]">· {b.provider}</span>}
+              </li>
+            ))}
+          </ul>
         )}
-      </div>
+
+        {note ? (
+          <div className="space-y-1">
+            {note.title && <p className="text-sm font-medium text-[var(--text)]">{note.title}</p>}
+            {note.notes && <MarkdownView value={note.notes} className="text-xs leading-relaxed text-[var(--muted)]" />}
+            {dayPlaces.length > 0 && (
+              <div className="flex flex-wrap gap-1 pt-1">
+                {dayPlaces.map(place => (
+                  <a
+                    key={place.id}
+                    href={getPlaceMapUrl(place)}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    title={place.location ?? place.name}
+                    className="inline-flex min-w-0 max-w-full items-center gap-1 rounded-full border border-[var(--amber)]/60 bg-[var(--amber-d)] px-2 py-0.5 text-xs text-[var(--amber)] transition-colors hover:opacity-80"
+                  >
+                    <PinIcon />
+                    <span className="max-w-[10rem] truncate">{place.name}</span>
+                  </a>
+                ))}
+              </div>
+            )}
+          </div>
+        ) : (
+          dayBookings.length === 0 && (
+            <p className="text-xs italic text-[var(--subtle)]">No bookings or notes for this day.</p>
+          )
+        )}
+      </Collapsible>
     </>
   );
 }

--- a/packages/hub/src/app/travel/coming-next.utils.test.ts
+++ b/packages/hub/src/app/travel/coming-next.utils.test.ts
@@ -106,7 +106,7 @@ describe('mapBookingsToSegments', () => {
     expect(segments[0]!.isActive).toBe(true);
   });
 
-  it('detects active booking with no endAt (within 2h window)', () => {
+  it('detects active booking with no endAt (within 1h window)', () => {
     const bookings = [makeBooking({ id: 1, startAt: new Date('2026-03-31T09:00:00Z') })];
     const segments = mapBookingsToSegments(bookings, [], now);
     expect(segments[0]!.isActive).toBe(true);
@@ -388,6 +388,78 @@ describe('mapBookingsToSegments', () => {
     expect(segments[0]!.isPast).toBe(true);
     expect(segments[0]!.timeBucket).toBe('past');
     expect(segments[0]!.isActive).toBe(false);
+  });
+
+  it('marks multi-day booking start segment as past once the start moment has elapsed, even though the booking itself is still ongoing', () => {
+    // Check-in was yesterday at 09:00, checkout is in 4 days — now is comfortably
+    // past the 1h grace window around check-in, so the start segment should read
+    // "past", not stay "now" for the entire multi-day stay.
+    const bookings = [
+      makeBooking({
+        id: 1,
+        bookingType: 'accommodation',
+        startAt: new Date('2026-03-30T09:00:00Z'),
+        endAt: new Date('2026-04-04T11:00:00Z'),
+      }),
+    ];
+    const segments = mapBookingsToSegments(bookings, [], now);
+    const startSegment = segments.find(s => s.segmentId === '1-start')!;
+    expect(startSegment.timeBucket).toBe('past');
+    expect(startSegment.isActive).toBe(false);
+    expect(startSegment.isPast).toBe(true);
+  });
+
+  it('keeps end segment "now" for up to 1h after its own moment (e.g. plane arriving)', () => {
+    // Flight departed yesterday and landed 30min before "now" — the arrival end segment
+    // should still read "now" (deplaning/baggage claim), based on its own datetime,
+    // independent of the start segment which is long past.
+    const bookings = [
+      makeBooking({
+        id: 1,
+        bookingType: 'flight',
+        startAt: new Date('2026-03-30T09:00:00Z'),
+        endAt: new Date('2026-03-31T09:30:00Z'),
+      }),
+    ];
+    const segments = mapBookingsToSegments(bookings, [], now);
+    const endSegment = segments.find(s => s.segmentId === '1-end')!;
+    expect(endSegment.timeBucket).toBe('now');
+    expect(endSegment.isActive).toBe(true);
+    expect(endSegment.isPast).toBe(false);
+  });
+
+  it('marks end segment as past once more than 1h has elapsed since its own moment', () => {
+    const bookings = [
+      makeBooking({
+        id: 1,
+        bookingType: 'flight',
+        startAt: new Date('2026-03-30T09:00:00Z'),
+        endAt: new Date('2026-03-31T08:00:00Z'),
+      }),
+    ];
+    const segments = mapBookingsToSegments(bookings, [], now);
+    const endSegment = segments.find(s => s.segmentId === '1-end')!;
+    expect(endSegment.timeBucket).toBe('past');
+    expect(endSegment.isActive).toBe(false);
+    expect(endSegment.isPast).toBe(true);
+  });
+
+  it('caps the start segment active window to the booking duration when shorter than 1h', () => {
+    // A 20-minute transfer: the start ("Pickup") segment should not still read "now"
+    // once the entire booking (pickup -> drop-off) has already finished.
+    const bookings = [
+      makeBooking({
+        id: 1,
+        bookingType: 'transfer',
+        startAt: new Date('2026-03-31T09:30:00Z'),
+        endAt: new Date('2026-03-31T09:50:00Z'),
+      }),
+    ];
+    const segments = mapBookingsToSegments(bookings, [], now);
+    const startSegment = segments.find(s => s.segmentId === '1-start')!;
+    expect(startSegment.timeBucket).toBe('past');
+    expect(startSegment.isActive).toBe(false);
+    expect(startSegment.isPast).toBe(true);
   });
 
   it('marks active booking timeBucket=now', () => {

--- a/packages/hub/src/app/travel/coming-next.utils.ts
+++ b/packages/hub/src/app/travel/coming-next.utils.ts
@@ -361,17 +361,22 @@ export function mapBookingsToSegments(
   }
 
   const nowMs = now.getTime();
-  const TWO_HOURS = 2 * 60 * 60 * 1000;
   const ONE_HOUR = 60 * 60 * 1000;
   const TWENTY_FOUR_HOURS = 24 * 60 * 60 * 1000;
+  const ACTIVE_WINDOW = ONE_HOUR; // each segment is "now" for up to 1h around its own moment
 
+  // Buckets a single point-in-time event (a segment's own datetime) using a short grace
+  // window around it, instead of the booking's full start..end span. This way a flight
+  // arrival, hotel check-in, or car pickup only reads "Now" briefly around the actual
+  // moment, then "Past" — even though the underlying booking may still be ongoing.
   function timeBucketFor(
-    startMs: number,
-    endMs: number,
+    eventMs: number,
+    windowMs: number = ACTIVE_WINDOW,
   ): { timeBucket: TimeBucket; isActive: boolean; isPast: boolean } {
-    const isActive = nowMs >= startMs && nowMs <= endMs;
-    const isPast = endMs < nowMs;
-    const diffMs = startMs - nowMs;
+    const windowEnd = eventMs + windowMs;
+    const isActive = nowMs >= eventMs && nowMs <= windowEnd;
+    const isPast = windowEnd < nowMs;
+    const diffMs = eventMs - nowMs;
     let timeBucket: TimeBucket;
     if (isPast) timeBucket = 'past';
     else if (isActive) timeBucket = 'now';
@@ -395,11 +400,13 @@ export function mapBookingsToSegments(
     const fd = booking.flightData;
 
     const startMs = new Date(booking.startAt!).getTime();
-    const endMs = booking.endAt ? new Date(booking.endAt).getTime() : startMs + TWO_HOURS;
+    const endMs = booking.endAt ? new Date(booking.endAt).getTime() : null;
     const duration = computeDuration(booking, fd);
 
-    // Start segment
-    const startBucket = timeBucketFor(startMs, booking.endAt ? endMs : startMs + TWO_HOURS);
+    // Start segment — own moment, capped to the booking's actual duration if that's
+    // shorter than the 1h grace window (e.g. a 20-minute transfer).
+    const startWindow = endMs != null ? Math.max(Math.min(ACTIVE_WINDOW, endMs - startMs), 0) : ACTIVE_WINDOW;
+    const startBucket = timeBucketFor(startMs, startWindow);
     segments.push({
       segmentId: `${booking.id}-start`,
       bookingId: booking.id,
@@ -415,9 +422,10 @@ export function mapBookingsToSegments(
       ...startBucket,
     });
 
-    // End segment — only when endAt is explicitly set
-    if (booking.endAt) {
-      const endBucket = timeBucketFor(endMs, endMs);
+    // End segment — only when endAt is explicitly set. Own moment, same 1h grace window
+    // (e.g. a flight "Arrival" stays "Now" briefly for deplaning, then goes "Past").
+    if (booking.endAt && endMs != null) {
+      const endBucket = timeBucketFor(endMs);
       segments.push({
         segmentId: `${booking.id}-end`,
         bookingId: booking.id,

--- a/packages/hub/src/components/Collapsible.test.tsx
+++ b/packages/hub/src/components/Collapsible.test.tsx
@@ -63,6 +63,17 @@ describe('Collapsible', () => {
     expect(screen.getByRole('button', { name: 'Collapse' }).getAttribute('aria-expanded')).toBe('true');
   });
 
+  it('omits the toggle icon button when showIcon is false, but still toggles on label click', () => {
+    render(
+      <Collapsible label="Section" defaultOpen={true} showIcon={false}>
+        <p>Body content</p>
+      </Collapsible>,
+    );
+    expect(screen.queryByRole('button', { name: 'Collapse' })).toBeNull();
+    fireEvent.click(screen.getByText('Section'));
+    expect(screen.queryByText('Body content')).toBeNull();
+  });
+
   it('renders leading, inlineActions, and actions slots', () => {
     render(
       <Collapsible

--- a/packages/hub/src/components/Collapsible.test.tsx
+++ b/packages/hub/src/components/Collapsible.test.tsx
@@ -1,0 +1,81 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { Collapsible } from './Collapsible';
+
+describe('Collapsible', () => {
+  it('renders children when open by default', () => {
+    render(
+      <Collapsible label="Section">
+        <p>Body content</p>
+      </Collapsible>,
+    );
+    expect(screen.getByText('Body content')).toBeTruthy();
+  });
+
+  it('hides children when defaultOpen is false', () => {
+    render(
+      <Collapsible label="Section" defaultOpen={false}>
+        <p>Body content</p>
+      </Collapsible>,
+    );
+    expect(screen.queryByText('Body content')).toBeNull();
+  });
+
+  it('toggles open state when the icon button is clicked', () => {
+    render(
+      <Collapsible label="Section" defaultOpen={false}>
+        <p>Body content</p>
+      </Collapsible>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Expand' }));
+    expect(screen.getByText('Body content')).toBeTruthy();
+  });
+
+  it('toggles open state when the label is clicked', () => {
+    render(
+      <Collapsible label="Section" defaultOpen={true}>
+        <p>Body content</p>
+      </Collapsible>,
+    );
+    fireEvent.click(screen.getByText('Section'));
+    expect(screen.queryByText('Body content')).toBeNull();
+  });
+
+  it('supports controlled open state via open/onOpenChange', () => {
+    const onOpenChange = vi.fn();
+    render(
+      <Collapsible label="Section" open={false} onOpenChange={onOpenChange}>
+        <p>Body content</p>
+      </Collapsible>,
+    );
+    expect(screen.queryByText('Body content')).toBeNull();
+    fireEvent.click(screen.getByText('Section'));
+    expect(onOpenChange).toHaveBeenCalledWith(true);
+    expect(screen.queryByText('Body content')).toBeNull();
+  });
+
+  it('sets aria-expanded on the toggle button to reflect open state', () => {
+    render(
+      <Collapsible label="Section" defaultOpen={true}>
+        <p>Body content</p>
+      </Collapsible>,
+    );
+    expect(screen.getByRole('button', { name: 'Collapse' }).getAttribute('aria-expanded')).toBe('true');
+  });
+
+  it('renders leading, inlineActions, and actions slots', () => {
+    render(
+      <Collapsible
+        label="Section"
+        leading={<span>Leading</span>}
+        inlineActions={<span>InlineActions</span>}
+        actions={<span>Actions</span>}
+      >
+        <p>Body content</p>
+      </Collapsible>,
+    );
+    expect(screen.getByText('Leading')).toBeTruthy();
+    expect(screen.getByText('InlineActions')).toBeTruthy();
+    expect(screen.getByText('Actions')).toBeTruthy();
+  });
+});

--- a/packages/hub/src/components/Collapsible.tsx
+++ b/packages/hub/src/components/Collapsible.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import { useState, type ReactNode } from 'react';
+import { cn } from '@/lib/utils';
+import { IconButton } from './IconButton';
+import { ChevronRightOutlineIcon } from './icons';
+
+export type CollapsibleVariant = 'box' | 'text';
+
+export type CollapsibleProps = {
+  label: ReactNode;
+  children: ReactNode;
+  variant?: CollapsibleVariant;
+  defaultOpen?: boolean;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  leading?: ReactNode;
+  inlineActions?: ReactNode;
+  actions?: ReactNode;
+  className?: string;
+  headerClassName?: string;
+  contentClassName?: string;
+};
+
+export function Collapsible({
+  label,
+  children,
+  variant = 'box',
+  defaultOpen = true,
+  open,
+  onOpenChange,
+  leading,
+  inlineActions,
+  actions,
+  className,
+  headerClassName,
+  contentClassName,
+}: CollapsibleProps) {
+  const [internalOpen, setInternalOpen] = useState(defaultOpen);
+  const isOpen = open ?? internalOpen;
+
+  function toggle() {
+    const next = !isOpen;
+    if (open === undefined) setInternalOpen(next);
+    onOpenChange?.(next);
+  }
+
+  return (
+    <div
+      className={cn(
+        variant === 'box' && 'space-y-3 rounded-lg border border-[var(--border)] bg-[var(--card)] p-4',
+        className,
+      )}
+    >
+      <div className={cn('flex items-center justify-between gap-2', variant === 'text' && 'mb-1.5', headerClassName)}>
+        <div className="flex min-w-0 items-center gap-1.5">
+          {leading}
+          <IconButton
+            label={isOpen ? 'Collapse' : 'Expand'}
+            icon={
+              <ChevronRightOutlineIcon
+                className={cn('size-3.5 transition-transform duration-200', isOpen && 'rotate-90')}
+              />
+            }
+            onClick={toggle}
+            variant="ghost"
+            aria-expanded={isOpen}
+            className="shrink-0 rounded p-1 text-[var(--subtle)] hover:bg-[var(--card2)] hover:text-[var(--text)]"
+          />
+          <span
+            onClick={toggle}
+            className={cn(
+              'min-w-0 cursor-pointer truncate select-none',
+              variant === 'box'
+                ? 'text-sm font-semibold text-[var(--text)]'
+                : 'text-[13px] font-semibold text-[var(--text)]',
+            )}
+          >
+            {label}
+          </span>
+          {inlineActions}
+        </div>
+        {actions}
+      </div>
+      {isOpen && <div className={contentClassName}>{children}</div>}
+    </div>
+  );
+}

--- a/packages/hub/src/components/Collapsible.tsx
+++ b/packages/hub/src/components/Collapsible.tsx
@@ -14,6 +14,7 @@ export type CollapsibleProps = {
   defaultOpen?: boolean;
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
+  showIcon?: boolean;
   leading?: ReactNode;
   inlineActions?: ReactNode;
   actions?: ReactNode;
@@ -29,6 +30,7 @@ export function Collapsible({
   defaultOpen = true,
   open,
   onOpenChange,
+  showIcon = true,
   leading,
   inlineActions,
   actions,
@@ -55,18 +57,20 @@ export function Collapsible({
       <div className={cn('flex items-center justify-between gap-2', variant === 'text' && 'mb-1.5', headerClassName)}>
         <div className="flex min-w-0 items-center gap-1.5">
           {leading}
-          <IconButton
-            label={isOpen ? 'Collapse' : 'Expand'}
-            icon={
-              <ChevronRightOutlineIcon
-                className={cn('size-3.5 transition-transform duration-200', isOpen && 'rotate-90')}
-              />
-            }
-            onClick={toggle}
-            variant="ghost"
-            aria-expanded={isOpen}
-            className="shrink-0 rounded p-1 text-[var(--subtle)] hover:bg-[var(--card2)] hover:text-[var(--text)]"
-          />
+          {showIcon && (
+            <IconButton
+              label={isOpen ? 'Collapse' : 'Expand'}
+              icon={
+                <ChevronRightOutlineIcon
+                  className={cn('size-3.5 transition-transform duration-200', isOpen && 'rotate-90')}
+                />
+              }
+              onClick={toggle}
+              variant="ghost"
+              aria-expanded={isOpen}
+              className="shrink-0 rounded p-1 text-[var(--subtle)] hover:bg-[var(--card2)] hover:text-[var(--text)]"
+            />
+          )}
           <span
             onClick={toggle}
             className={cn(

--- a/packages/hub/src/components/Collapsible.tsx
+++ b/packages/hub/src/components/Collapsible.tsx
@@ -74,10 +74,8 @@ export function Collapsible({
           <span
             onClick={toggle}
             className={cn(
-              'min-w-0 cursor-pointer truncate select-none',
-              variant === 'box'
-                ? 'text-sm font-semibold text-[var(--text)]'
-                : 'text-[13px] font-semibold text-[var(--text)]',
+              'min-w-0 cursor-pointer truncate select-none font-semibold text-[var(--text)]',
+              variant === 'box' ? 'text-sm' : 'text-[13px]',
             )}
           >
             {label}

--- a/packages/hub/src/components/DisclosureToggle.tsx
+++ b/packages/hub/src/components/DisclosureToggle.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { ReactNode, useEffect, useState } from 'react';
-import { ChevronDownOutlineIcon, ChevronRightOutlineIcon } from './icons';
+import { Collapsible } from './Collapsible';
 
 export type DisclosureToggleProps = {
   label: string;
@@ -34,20 +34,16 @@ export function DisclosureToggle({
     }
   }, [openSignal]);
 
-  const ToggleIcon = isOpen ? ChevronDownOutlineIcon : ChevronRightOutlineIcon;
-
   return (
-    <div className={className ?? 'space-y-3'}>
-      <button
-        type="button"
-        className="text-xs text-zinc-400 hover:text-zinc-200 transition-colors flex items-center gap-1"
-        onClick={() => setIsOpen(v => !v)}
-      >
-        <ToggleIcon className="size-3.5" />
-        <span>{label}</span>
-      </button>
-
-      {isOpen ? <div className={contentClassName}>{children}</div> : null}
-    </div>
+    <Collapsible
+      variant="text"
+      label={label}
+      open={isOpen}
+      onOpenChange={setIsOpen}
+      className={className}
+      contentClassName={contentClassName}
+    >
+      {children}
+    </Collapsible>
   );
 }

--- a/packages/hub/src/components/IconButton.tsx
+++ b/packages/hub/src/components/IconButton.tsx
@@ -12,6 +12,7 @@ interface Props {
   disabled?: boolean;
   className?: string;
   variant?: 'default' | 'ghost';
+  'aria-expanded'?: boolean;
 }
 
 const variantClassName = {
@@ -28,6 +29,7 @@ export function IconButton({
   disabled = false,
   className,
   variant = 'default',
+  'aria-expanded': ariaExpanded,
 }: Props) {
   const content = loading ? <SpinnerIcon className="opacity-70" /> : icon;
   const base = variantClassName[variant];
@@ -47,6 +49,7 @@ export function IconButton({
       className={cn(base, 'disabled:opacity-50', className)}
       aria-label={label}
       title={label}
+      aria-expanded={ariaExpanded}
     >
       {content}
     </button>

--- a/packages/hub/src/components/index.ts
+++ b/packages/hub/src/components/index.ts
@@ -7,6 +7,8 @@ export { Card } from './Card';
 export type { CardProps } from './Card';
 export { Checkbox } from './Checkbox';
 export { ColorPicker } from './ColorPicker';
+export { Collapsible } from './Collapsible';
+export type { CollapsibleProps, CollapsibleVariant } from './Collapsible';
 export { ConfirmModal } from './ConfirmModal';
 export { DatePicker } from './DatePicker';
 export type { DatePickerProps, DateMode } from './DatePicker';

--- a/packages/hub/src/components/stories/Collapsible.stories.tsx
+++ b/packages/hub/src/components/stories/Collapsible.stories.tsx
@@ -40,3 +40,8 @@ export const WithLeadingAndActions: Story = {
     actions: <span className="text-[11px] font-semibold text-[var(--muted)]">$120 / $300</span>,
   },
 };
+
+export const NoIcon: Story = {
+  name: 'Text / No icon',
+  args: { variant: 'text', showIcon: false },
+};

--- a/packages/hub/src/components/stories/Collapsible.stories.tsx
+++ b/packages/hub/src/components/stories/Collapsible.stories.tsx
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { Collapsible } from '../Collapsible';
+
+const meta: Meta<typeof Collapsible> = {
+  title: 'Components/Collapsible',
+  component: Collapsible,
+  tags: ['autodocs'],
+  args: {
+    label: 'Section title',
+    children: <p className="text-sm text-[var(--text)]">Collapsible content goes here.</p>,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Collapsible>;
+
+export const Box: Story = {
+  args: { variant: 'box' },
+};
+
+export const BoxCollapsed: Story = {
+  name: 'Box / Collapsed',
+  args: { variant: 'box', defaultOpen: false },
+};
+
+export const Text: Story = {
+  args: { variant: 'text' },
+};
+
+export const TextCollapsed: Story = {
+  name: 'Text / Collapsed',
+  args: { variant: 'text', defaultOpen: false },
+};
+
+export const WithLeadingAndActions: Story = {
+  name: 'Text / Leading + Actions',
+  args: {
+    variant: 'text',
+    leading: <div className="h-2.5 w-2.5 shrink-0 rounded-[3px] bg-[var(--accent)]" />,
+    actions: <span className="text-[11px] font-semibold text-[var(--muted)]">$120 / $300</span>,
+  },
+};


### PR DESCRIPTION
Each itinerary segment (start and end) now buckets its own datetime
independently with a max 1h grace window, instead of borrowing the
booking's full start..end span. This fixes multi-day bookings (e.g. a
5-night hotel stay) showing "Now" on Check-in/Pickup long after that
moment has passed, and lets end-segment events like a flight arrival
keep a short "Now" window of their own (deplaning) rather than going
instantly to "Past".

Also makes Day by Day cards collapsible, collapsed by default for past
days.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011eSxpgdP6CWcezyHsBQn5u