### PR TITLE
Add itemName fuzzy filter to finances_query_transactions

### DIFF
--- a/packages/mcp-server/src/finances/tools/tools.ts
+++ b/packages/mcp-server/src/finances/tools/tools.ts
@@ -212,6 +212,7 @@ const financeTools = [
     description:
       'Search and list transactions with optional filters. Returns resolved account, category, and payee names inline. ' +
       'payeeName matching is alias-aware for existing payees. ' +
+      'itemName performs a fuzzy match against receipt line item names captured in extras (e.g. find the transaction where you bought "Carlsberg" beer), independent of the includeExtras flag. ' +
       'Correction transactions are excluded by default. Supports pagination via limit/offset.',
     inputSchema: QueryTransactionsSchema.strict(),
     annotations: { readOnlyHint: true },

--- a/packages/mcp-server/src/finances/tools/transactions.ts
+++ b/packages/mcp-server/src/finances/tools/transactions.ts
@@ -612,6 +612,12 @@ export const QueryTransactionsSchema = z.object({
   includeCorrections: z.boolean().optional(),
   addedByUserId: z.string().optional(),
   search: z.string().optional(),
+  itemName: z
+    .string()
+    .optional()
+    .describe(
+      'Fuzzy (case-insensitive partial) match against receipt line item names captured in extras, e.g. "Carlsberg" to find transactions where a receipt item name contains that text. Only matches transactions with parsed receipt items.',
+    ),
   limit: z.number().int().min(1).max(200).optional(),
   offset: z.number().int().min(0).optional(),
   includeExtras: z
@@ -654,6 +660,7 @@ export const queryTransactionsTool: ToolHandler<typeof QueryTransactionsSchema> 
     includeCorrections: input.includeCorrections,
     addedByUserId: input.addedByUserId,
     search: input.search,
+    itemName: input.itemName,
     limit: input.limit ?? 50,
     offset: input.offset ?? 0,
   });

--- a/packages/shared/src/services/finances/transactions.ts
+++ b/packages/shared/src/services/finances/transactions.ts
@@ -2,7 +2,7 @@
  * Finance transaction CRUD
  * - addTransaction(userId, budgetId, data) — inserts a transaction; updates account balances and payee stats
  * - addCorrectionTransaction(userId, budgetId, data) — balance correction by target value; delta computed atomically from live DB balance; returns CorrectionResult or null if already at target
- * - getTransactions(userId, budgetId, opts?) — lists transactions with optional filters (accountId, categoryId, type, fromDate, toDate, includeCorrections, search, label, amountGte, amountLte, limit, offset)
+ * - getTransactions(userId, budgetId, opts?) — lists transactions with optional filters (accountId, categoryId, type, fromDate, toDate, includeCorrections, search, itemName, label, amountGte, amountLte, limit, offset)
  * - getTransactionListItems(userId, budgetId, opts?) — same filters as getTransactions; returns pre-resolved display fields (accountName/Currency, toAccountName/Currency, categoryId/Name/Color/Icon, payeeId/Name, addedByUserId/Initials, createdAt, balances) via JOIN
  * - getTransactionListItemById(userId, budgetId, transactionId) — single TransactionListItem with resolved display fields; null if not found
  * - countTransactions(userId, budgetId, opts?) — same filters; returns total count
@@ -67,6 +67,7 @@ export interface GetTransactionsOpts {
   toDate?: string;
   includeCorrections?: boolean;
   search?: string;
+  itemName?: string;
   label?: string;
   addedByUserId?: string;
   amountGte?: number;
@@ -150,6 +151,13 @@ function buildListConditions(budgetId: number, opts: GetTransactionsOpts) {
   }
   if (opts.search !== undefined && opts.search.trim() !== '') {
     conditions.push(ilike(financeTransactions.notes, `%${opts.search}%`));
+  }
+  if (opts.itemName !== undefined && opts.itemName.trim() !== '') {
+    // Fuzzy match against receipt line item names stored in extras.items[].name (see TransactionDetails).
+    conditions.push(sql`EXISTS (
+      SELECT 1 FROM jsonb_array_elements(${financeTransactions.extras}->'items') AS item
+      WHERE item->>'name' ILIKE ${`%${opts.itemName.trim()}%`}
+    )`);
   }
   if (opts.label !== undefined) {
     conditions.push(sql`${financeTransactions.labels} @> ${JSON.stringify([opts.label])}::jsonb`);


### PR DESCRIPTION
Allows searching transactions by receipt line item name (stored in
extras.items[].name), e.g. finding the transaction where Carlsberg
beer was purchased, without needing to set includeExtras.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015AwxMHxR7RQt8DfSxKtp7e