### PR TITLE
Fix filter inconsistencies in finances_query_transactions

### DIFF
--- a/packages/mcp-server/src/finances/tools/transactions.test.ts
+++ b/packages/mcp-server/src/finances/tools/transactions.test.ts
@@ -571,8 +571,8 @@ describe('queryTransactionsTool', () => {
         includeCorrections: undefined,
         addedByUserId: undefined,
         search: undefined,
-        limit: undefined,
-        offset: undefined,
+        limit: 50,
+        offset: 0,
       },
       financesContext,
     );

--- a/packages/mcp-server/src/finances/tools/transactions.ts
+++ b/packages/mcp-server/src/finances/tools/transactions.ts
@@ -574,7 +574,14 @@ export const deleteTransactionTool: ToolHandler<typeof DeleteTransactionSchema.s
 // ─── query_transactions ───────────────────────────────────────────────────────
 
 export const QueryTransactionsSchema = z.object({
-  accountId: z.number().int().positive().optional(),
+  accountId: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .describe(
+      'Filter by account. Matches transactions where this account is either the source or destination (for transfers).',
+    ),
   categoryId: z
     .number()
     .int()
@@ -587,10 +594,14 @@ export const QueryTransactionsSchema = z.object({
     .optional()
     .nullable()
     .describe(
-      'Filter by payee name. Performs a case-insensitive partial match against payee names and aliases. Pass null to find transactions with no payee.',
+      "Filter by payee name. Performs a case-insensitive exact match against the payee's canonical name or any of its aliases. Pass null to find transactions with no payee.",
     ),
-  label: z.string().optional(),
-  type: z.enum(TransactionTypes).optional(),
+  label: z
+    .string()
+    .optional()
+    .nullable()
+    .describe('Filter by label (exact match, case-sensitive). Pass null to find transactions with no labels.'),
+  type: z.enum(TransactionTypes).optional().describe('Filter by transaction type.'),
   fromDate: z
     .string()
     .regex(/^\d{4}-\d{2}-\d{2}$/)
@@ -609,17 +620,26 @@ export const QueryTransactionsSchema = z.object({
     .number()
     .optional()
     .describe('Filter transactions with amount less than or equal to this value (in account currency).'),
-  includeCorrections: z.boolean().optional(),
-  addedByUserId: z.string().optional(),
-  search: z.string().optional(),
+  includeCorrections: z
+    .boolean()
+    .optional()
+    .describe('When true, include balance-correction transactions. Excluded by default.'),
+  addedByUserId: z.string().optional().describe('Filter by the user who added the transaction.'),
+  search: z.string().optional().describe('Partial (case-insensitive substring) match against transaction notes.'),
   itemName: z
     .string()
     .optional()
     .describe(
-      'Fuzzy (case-insensitive partial) match against receipt line item names captured in extras, e.g. "Carlsberg" to find transactions where a receipt item name contains that text. Only matches transactions with parsed receipt items.',
+      'Partial (case-insensitive substring) match against receipt line item names captured in extras, e.g. "Carlsberg" to find transactions where a receipt item name contains that text. Only matches transactions with parsed receipt items.',
     ),
-  limit: z.number().int().min(1).max(200).optional(),
-  offset: z.number().int().min(0).optional(),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(200)
+    .default(50)
+    .describe('Maximum number of transactions to return (default 50, max 200).'),
+  offset: z.number().int().min(0).default(0).describe('Number of transactions to skip for pagination (default 0).'),
   includeExtras: z
     .boolean()
     .optional()
@@ -661,8 +681,8 @@ export const queryTransactionsTool: ToolHandler<typeof QueryTransactionsSchema> 
     addedByUserId: input.addedByUserId,
     search: input.search,
     itemName: input.itemName,
-    limit: input.limit ?? 50,
-    offset: input.offset ?? 0,
+    limit: input.limit,
+    offset: input.offset,
   });
 
   const [txns, total] = await Promise.all([

--- a/packages/shared/src/services/finances/transactions.ts
+++ b/packages/shared/src/services/finances/transactions.ts
@@ -2,7 +2,7 @@
  * Finance transaction CRUD
  * - addTransaction(userId, budgetId, data) — inserts a transaction; updates account balances and payee stats
  * - addCorrectionTransaction(userId, budgetId, data) — balance correction by target value; delta computed atomically from live DB balance; returns CorrectionResult or null if already at target
- * - getTransactions(userId, budgetId, opts?) — lists transactions with optional filters (accountId, categoryId, type, fromDate, toDate, includeCorrections, search, itemName, label, amountGte, amountLte, limit, offset)
+ * - getTransactions(userId, budgetId, opts?) — lists transactions with optional filters (accountId, categoryId, type, fromDate, toDate, includeCorrections, search, itemName, label [string | null — null finds transactions with no labels], amountGte, amountLte, limit, offset)
  * - getTransactionListItems(userId, budgetId, opts?) — same filters as getTransactions; returns pre-resolved display fields (accountName/Currency, toAccountName/Currency, categoryId/Name/Color/Icon, payeeId/Name, addedByUserId/Initials, createdAt, balances) via JOIN
  * - getTransactionListItemById(userId, budgetId, transactionId) — single TransactionListItem with resolved display fields; null if not found
  * - countTransactions(userId, budgetId, opts?) — same filters; returns total count
@@ -68,7 +68,7 @@ export interface GetTransactionsOpts {
   includeCorrections?: boolean;
   search?: string;
   itemName?: string;
-  label?: string;
+  label?: string | null;
   addedByUserId?: string;
   amountGte?: number;
   amountLte?: number;
@@ -159,7 +159,9 @@ function buildListConditions(budgetId: number, opts: GetTransactionsOpts) {
       WHERE item->>'name' ILIKE ${`%${opts.itemName.trim()}%`}
     )`);
   }
-  if (opts.label !== undefined) {
+  if (opts.label === null) {
+    conditions.push(sql`jsonb_array_length(${financeTransactions.labels}) = 0`);
+  } else if (opts.label !== undefined) {
     conditions.push(sql`${financeTransactions.labels} @> ${JSON.stringify([opts.label])}::jsonb`);
   }
   if (opts.addedByUserId !== undefined) {


### PR DESCRIPTION
- Correct payeeName description: it does an exact match (not partial)
  against payee name/aliases
- Rename "fuzzy" to "partial (substring)" for itemName/search to match
  actual ILIKE behavior; reserve "fuzzy" for true typo-tolerant search
  like list_payees
- Document every previously-undocumented param (accountId, type, label,
  includeCorrections, addedByUserId, limit, offset)
- Add label: null support to find transactions with no labels, matching
  the existing categoryId/payeeName null pattern
- Give limit/offset Zod defaults so they're visible in the published
  tool schema, matching list_payees

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LG7x3TJXSdeoWHL1tuNkva