### PR TITLE
Mark closed accounts in generated Claude Project instructions

### DIFF
--- a/packages/hub/src/app/finances/settings/ClaudePromptSection.tsx
+++ b/packages/hub/src/app/finances/settings/ClaudePromptSection.tsx
@@ -33,6 +33,9 @@ function buildPrompt(
     if (acct.targetAmount != null) {
       entry += `, target ${acct.targetAmount.toLocaleString()}`;
     }
+    if (acct.archived) {
+      entry += ' (closed)';
+    }
     lines.push(entry);
   }
 


### PR DESCRIPTION
Archived accounts were listed identically to active ones in the
generated instructions block, giving the assistant no way to tell a
closed account shouldn't be used for new transactions.