### PR TITLE
Only count transfers into Loan accounts as spending

### DIFF
--- a/docs/requirements/hub/feature-finances.md
+++ b/docs/requirements/hub/feature-finances.md
@@ -122,9 +122,9 @@ finances layout with sidebar navigation on desktop and bottom-tab navigation on 
 - [x] Clicking a category opens a dedicated category details screen with summary details on top and transactions listed below.
 - [x] Category details transactions are shown ordered by date descending (with id tie-breaker descending).
 - [x] Dashboard budget categories are shown in descending order by amount spent.
-- [x] The Reporting page's Spending Trend chart includes categorized transfers (e.g. loan repayments) in its daily totals, matching the Dashboard "Spending" chart.
+- [x] The Reporting page's Spending Trend chart includes categorized loan-repayment transfers (transfers into a Loan account) in its daily totals, matching the Dashboard "Spending" chart; transfers into Goal/Tracking/Investment accounts (savings, IBKR, etc.) are excluded from spending totals even when categorized.
 - [x] The Reporting "Net" summary card renders a single leading sign (`-`/`+`) for negative/positive values, without doubling the currency formatter's own minus sign.
-- [x] Bank and Cash account rows on the Accounts page show current-month income (green) and spending (red, including categorized transfers) under the account name.
+- [x] Bank and Cash account rows on the Accounts page show current-month income (green) and spending (red, including categorized loan-repayment transfers only) under the account name.
 - [x] Selecting an account filter on the Reporting page shows an "Income vs Spending" card for that account covering the active period (month/range/all).
 - [x] The Payees list shows correct totals/transaction counts for payees with expense history anywhere in the selected range, even when the budget has a large number of transactions.
 - [x] The Payee detail page shows a summary card (transaction count, total spent, average per transaction, total received if any, first/last transaction dates, top category, top account) above the transaction list.

--- a/packages/hub/src/app/api/finances/dashboard/route.ts
+++ b/packages/hub/src/app/api/finances/dashboard/route.ts
@@ -178,10 +178,16 @@ export const GET = route({ query: DashboardQuerySchema, response: dashboardRespo
     }),
   ]);
 
+  // Only transfers into a Loan account count as spending (loan repayments).
+  // Transfers into Goal/Tracking/Investment accounts are savings/investing, not spending.
+  const loanAccountIds = new Set(accounts.filter(a => a.type === AccountTypes.Loan).map(a => a.id));
+  const isLoanRepayment = (t: { categoryId: number | null; toAccountId: number | null }) =>
+    t.categoryId != null && t.toAccountId != null && loanAccountIds.has(t.toAccountId);
+
   // Monthly totals
   const monthlyExpense = expenseTxns.reduce((sum, t) => sum + t.amount, 0);
   const monthlyIncome = incomeTxns.reduce((sum, t) => sum + t.amount, 0);
-  const monthlyTransfers = transferTxns.reduce((sum, t) => (t.categoryId != null ? sum + t.amount : sum), 0);
+  const monthlyTransfers = transferTxns.reduce((sum, t) => (isLoanRepayment(t) ? sum + t.amount : sum), 0);
 
   // Single pass: category totals + daily map for current month
   const spentByCategory = new Map<number, number>();
@@ -194,8 +200,8 @@ export const GET = route({ query: DashboardQuerySchema, response: dashboardRespo
     currentDayMap.set(day, (currentDayMap.get(day) ?? 0) + t.amount);
   }
   for (const t of transferTxns) {
-    if (t.categoryId != null) {
-      spentByCategory.set(t.categoryId, (spentByCategory.get(t.categoryId) ?? 0) + t.amount);
+    if (isLoanRepayment(t)) {
+      spentByCategory.set(t.categoryId!, (spentByCategory.get(t.categoryId!) ?? 0) + t.amount);
       const day = +t.date.slice(8, 10);
       currentDayMap.set(day, (currentDayMap.get(day) ?? 0) + t.amount);
     }
@@ -207,7 +213,7 @@ export const GET = route({ query: DashboardQuerySchema, response: dashboardRespo
     prevDayMap.set(day, (prevDayMap.get(day) ?? 0) + t.amount);
   }
   for (const t of prevTransferTxns) {
-    if (t.categoryId != null) {
+    if (isLoanRepayment(t)) {
       const day = +t.date.slice(8, 10);
       prevDayMap.set(day, (prevDayMap.get(day) ?? 0) + t.amount);
     }

--- a/packages/hub/src/app/api/finances/reporting/route.ts
+++ b/packages/hub/src/app/api/finances/reporting/route.ts
@@ -5,13 +5,14 @@ import {
   getTransactionListItems,
   getTransactions,
   getAccountById,
+  getAccounts,
   getAccountsCashflow,
   getSavingsAndDebtFlows,
   getCategories,
   getGroups,
 } from '@my-hub/shared/services';
 import type { CategoryIcon } from '@my-hub/shared/constants';
-import { TransactionTypes } from '@my-hub/shared/constants';
+import { AccountTypes, TransactionTypes } from '@my-hub/shared/constants';
 import { monthToDateRange, shiftMonthStr, addDays, dateToString } from '@my-hub/shared/utils';
 import { supportedCurrencySchema } from '../currency.schema';
 import { categoryIconSchema, categoryColorSchema } from '../shared.schema';
@@ -207,9 +208,10 @@ export const GET = route({ query: QuerySchema, response: reportingResponseSchema
   const breakdownType = query.type === TransactionTypes.Income ? TransactionTypes.Income : TransactionTypes.Expense;
   const summaryType = query.type; // undefined = fetch both
 
-  // Categorized transfers (e.g. loan repayments) are counted as spending on the dashboard,
-  // so the spending trend needs them too for the two charts to agree.
+  // Categorized transfers into Loan accounts (loan repayments) are counted as spending on
+  // the dashboard, so the spending trend needs them too for the two charts to agree.
   const includeTransfers = query.dateMode === 'month' && breakdownType === TransactionTypes.Expense;
+  const loanAccountsPromise = includeTransfers ? getAccounts(user.id, budgetId) : Promise.resolve([]);
 
   // Fetch all needed transactions in parallel
   const [breakdownTxns, prevBreakdownTxns, incomeTxns, prevIncomeTxns, transferTxns, prevTransferTxns] =
@@ -407,13 +409,20 @@ export const GET = route({ query: QuerySchema, response: reportingResponseSchema
   if (query.dateMode === 'month') {
     const todayDay = monthStr === currentMonthStr ? new Date().getDate() : monthLastDay;
 
+    // Only transfers into a Loan account count as spending (loan repayments).
+    // Transfers into Goal/Tracking/Investment accounts are savings/investing, not spending.
+    const loanAccounts = await loanAccountsPromise;
+    const loanAccountIds = new Set(loanAccounts.filter(a => a.type === AccountTypes.Loan).map(a => a.id));
+    const isLoanRepayment = (t: { categoryId: number | null; toAccountId: number | null }) =>
+      t.categoryId != null && t.toAccountId != null && loanAccountIds.has(t.toAccountId);
+
     const currentDayMap = new Map<number, number>();
     for (const t of breakdownTxns) {
       const day = +t.date.slice(8, 10);
       currentDayMap.set(day, (currentDayMap.get(day) ?? 0) + t.amount);
     }
     for (const t of transferTxns) {
-      if (t.categoryId != null) {
+      if (isLoanRepayment(t)) {
         const day = +t.date.slice(8, 10);
         currentDayMap.set(day, (currentDayMap.get(day) ?? 0) + t.amount);
       }
@@ -424,7 +433,7 @@ export const GET = route({ query: QuerySchema, response: reportingResponseSchema
       prevDayMap.set(day, (prevDayMap.get(day) ?? 0) + t.amount);
     }
     for (const t of prevTransferTxns) {
-      if (t.categoryId != null) {
+      if (isLoanRepayment(t)) {
         const day = +t.date.slice(8, 10);
         prevDayMap.set(day, (prevDayMap.get(day) ?? 0) + t.amount);
       }

--- a/packages/shared/src/services/finances/reporting.ts
+++ b/packages/shared/src/services/finances/reporting.ts
@@ -5,7 +5,7 @@
  * - getSpendingByPayee(userId, budgetId, dateFrom, dateTo, limit?, categoryId?) — aggregated spend per payee, optional category filter
  * - getSpendingAggregates(userId, budgetId, opts) — flexible groupBy aggregation
  * - getComparison(userId, budgetId, opts) — side-by-side period comparison with absolute and percentage delta
- * - getAccountsCashflow(userId, budgetId, dateFrom, dateTo, accountIds?) — per-account income vs spending (expenses + categorized transfers) for a date range
+ * - getAccountsCashflow(userId, budgetId, dateFrom, dateTo, accountIds?) — per-account income vs spending (expenses + categorized transfers into Loan accounts) for a date range
  * - getSavingsAndDebtFlows(userId, budgetId, dateFrom, dateTo) — net transfers (in minus out) into Goal/Tracking (savings), Investment, and Loan (debt repayment) accounts for a date range
  * - getNetWorthSummary(userId, budgetId) — current net worth with account breakdown and history
  * Types: BudgetProgressResult, CashflowSummaryResult, SpendingByPayeeResult, SpendingAggregatesResult, ComparisonResult, ComparisonGroup, AccountCashflowResult, SavingsAndDebtFlowsResult, NetWorthSummaryResult, AccountNetWorth (includes optional loanSummary for loan accounts)
@@ -226,10 +226,11 @@ export interface AccountCashflowResult {
 
 /**
  * Returns per-account income vs spending totals for a date range.
- * "Spending" includes expense transactions plus transfer transactions that have a
- * category (e.g. loan repayments) sourced from the account; uncategorized transfers
- * are excluded entirely, matching the dashboard's "Spending" convention.
- * When accountIds is omitted, totals are computed for every account in the budget.
+ * "Spending" includes expense transactions plus transfer transactions that are
+ * categorized loan repayments (transfers into a Loan account); transfers into
+ * Goal/Tracking/Investment accounts are excluded, matching the dashboard's
+ * "Spending" convention. When accountIds is omitted, totals are computed for
+ * every account in the budget.
  */
 export async function getAccountsCashflow(
   userId: string,
@@ -260,14 +261,17 @@ export async function getAccountsCashflow(
       accountId: financeTransactions.accountId,
       type: financeTransactions.type,
       hasCategory: sql<boolean>`(${financeTransactions.categoryId} is not null)`,
+      isLoanRepayment: sql<boolean>`(${financeAccounts.type} = ${AccountTypes.Loan})`,
       total: sql<string>`sum(${financeTransactions.amount})`,
     })
     .from(financeTransactions)
+    .leftJoin(financeAccounts, eq(financeAccounts.id, financeTransactions.toAccountId))
     .where(and(...conditions))
     .groupBy(
       financeTransactions.accountId,
       financeTransactions.type,
       sql`(${financeTransactions.categoryId} is not null)`,
+      financeAccounts.type,
     );
 
   const result = new Map<number, AccountCashflowResult>();
@@ -276,7 +280,10 @@ export async function getAccountsCashflow(
     const amount = parseFloat(row.total ?? '0');
     if (row.type === TransactionTypes.Income) {
       entry.income += amount;
-    } else if (row.type === TransactionTypes.Expense || (row.type === TransactionTypes.Transfer && row.hasCategory)) {
+    } else if (
+      row.type === TransactionTypes.Expense ||
+      (row.type === TransactionTypes.Transfer && row.hasCategory && row.isLoanRepayment)
+    ) {
       entry.expenses += amount;
     }
     result.set(row.accountId, entry);


### PR DESCRIPTION
The Dashboard and Reporting spending trend/cashflow charts treated any
categorized transfer as spending, so moving money into Savings or
Investment accounts (categorized for tracking purposes) showed up as a
spike in "Spending" alongside genuine loan repayments. Restrict the
spending convention to transfers whose destination account is type
Loan.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QqjBMYminnBpgNaMyngNsv