### PR TITLE
Fix editing initial-balance and balance-correction transactions

### DIFF
--- a/packages/hub/src/app/finances/transactions/CorrectionEditModal.tsx
+++ b/packages/hub/src/app/finances/transactions/CorrectionEditModal.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { useState } from 'react';
+import { Input } from '@/components';
+import { apiFetch } from '@/lib/utils';
+import { FinModalShell } from '../FinModalShell';
+import type { TransactionListItem, TransactionMutationResponse } from '@/app/api/finances/transactions/route';
+
+type CorrectionEditModalProps = {
+  transaction: TransactionListItem;
+  currency: string;
+  onClose: () => void;
+  onSaved: (result?: TransactionMutationResponse) => void;
+};
+
+export function CorrectionEditModal({ transaction, currency, onClose, onSaved }: CorrectionEditModalProps) {
+  const [amount, setAmount] = useState(String(transaction.amount));
+  const [date, setDate] = useState(transaction.date);
+  const [saving, setSaving] = useState(false);
+
+  const parsed = parseFloat(amount);
+  const isInvalid = isNaN(parsed) || parsed <= 0 || !date;
+
+  const title = transaction.notes === 'Initial Balance' ? 'Edit Initial Balance' : 'Edit Balance Correction';
+
+  async function handleSave() {
+    if (isInvalid || saving) return;
+    setSaving(true);
+    try {
+      const result = await apiFetch<TransactionMutationResponse>(`/api/finances/transactions/${transaction.id}`, {
+        method: 'PATCH',
+        body: { amount: parsed, date },
+      });
+      onClose();
+      onSaved(result);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <FinModalShell
+      onClose={onClose}
+      title={title}
+      className="md:max-w-[400px]"
+      onSubmit={handleSave}
+      submitLabel="Save"
+      submitDisabled={isInvalid}
+      submitLoading={saving}
+    >
+      <div className="flex flex-col gap-3">
+        <div className="rounded-[10px] border border-[var(--border)] bg-[var(--card2)] px-3 py-[10px]">
+          <div className="mb-1 text-[9px] uppercase tracking-[0.07em] text-[var(--subtle)]">Account</div>
+          <div className="text-[13px] text-[var(--muted)]">{transaction.accountName}</div>
+        </div>
+
+        <div className="rounded-[10px] border border-[var(--border)] bg-[var(--card2)] px-3 py-[10px]">
+          <div className="mb-1 text-[9px] uppercase tracking-[0.07em] text-[var(--subtle)]">Amount ({currency})</div>
+          <Input
+            autoFocus
+            type="number"
+            value={amount}
+            onChange={e => setAmount(e.target.value)}
+            variant="ghost"
+            className="w-full border-none text-[15px] font-semibold text-[var(--text)]"
+          />
+        </div>
+
+        <div className="rounded-[10px] border border-[var(--border)] bg-[var(--card2)] px-3 py-[10px]">
+          <div className="mb-1 text-[9px] uppercase tracking-[0.07em] text-[var(--subtle)]">Date</div>
+          <Input
+            type="date"
+            value={date}
+            onChange={e => setDate(e.target.value)}
+            variant="ghost"
+            className="w-full border-none text-[13px] text-[var(--text)]"
+          />
+        </div>
+      </div>
+    </FinModalShell>
+  );
+}

--- a/packages/hub/src/app/finances/transactions/TransactionList.tsx
+++ b/packages/hub/src/app/finances/transactions/TransactionList.tsx
@@ -10,6 +10,7 @@ import { TransactionTypes } from '@my-hub/shared/constants';
 import { formatTransactionDate } from '../finances.utils';
 import { transactionEvents } from './transactionEvents';
 import { TransactionModal } from './TransactionModal';
+import { CorrectionEditModal } from './CorrectionEditModal';
 import { ConfirmDeleteModal } from './ConfirmDeleteModal';
 import { TransactionExtrasModal } from './TransactionExtrasModal';
 import type { TransactionDetails } from '@my-hub/shared/types';
@@ -67,6 +68,7 @@ export function TransactionList({
   const [offset, setOffset] = useState(0);
   const [hasMore, setHasMore] = useState(false);
   const [editId, setEditId] = useState<number | null>(null);
+  const [editCorrectionTx, setEditCorrectionTx] = useState<TransactionListItem | null>(null);
   const [pendingDeleteId, setPendingDeleteId] = useState<number | null>(null);
   const [openRowId, setOpenRowId] = useState<number | null>(null);
   const [extrasModal, setExtrasModal] = useState<TransactionDetails | null>(null);
@@ -208,7 +210,7 @@ export function TransactionList({
                 isOpen={openRowId === tx.id}
                 onOpen={() => setOpenRowId(tx.id)}
                 onClose={() => setOpenRowId(null)}
-                onEdit={() => setEditId(tx.id)}
+                onEdit={() => (tx.isCorrection ? setEditCorrectionTx(tx) : setEditId(tx.id))}
                 onDelete={() => setPendingDeleteId(tx.id)}
               >
                 <div className="flex items-center gap-2.5 py-2.5 pl-[14px] pr-[14px] md:pl-0 md:pr-2">
@@ -319,7 +321,7 @@ export function TransactionList({
                   <IconButton
                     label="Edit"
                     icon={<PencilIcon className="size-3.5" />}
-                    onClick={() => setEditId(tx.id)}
+                    onClick={() => (tx.isCorrection ? setEditCorrectionTx(tx) : setEditId(tx.id))}
                     className="bg-transparent p-1 text-[var(--muted)] hover:bg-[var(--card2)] hover:text-[var(--text)]"
                   />
                   <span className="h-3 w-px bg-[var(--border)]" />
@@ -355,6 +357,18 @@ export function TransactionList({
           onCloseAction={() => setEditId(null)}
           onSavedAction={() => {
             setEditId(null);
+            transactionEvents.emit('changed');
+          }}
+        />
+      )}
+
+      {editCorrectionTx && (
+        <CorrectionEditModal
+          transaction={editCorrectionTx}
+          currency={currency}
+          onClose={() => setEditCorrectionTx(null)}
+          onSaved={() => {
+            setEditCorrectionTx(null);
             transactionEvents.emit('changed');
           }}
         />


### PR DESCRIPTION
These rows are stored as plain transactions with isCorrection: true
and no category/payee, so editing them through the generic
TransactionModal left Save permanently disabled (category required)
and rendered the account field empty (its account type is excluded
from the expense account list). Route correction rows to a new,
purpose-built CorrectionEditModal that only exposes amount and date,
matching the existing precedent of using a dedicated modal for
balance corrections instead of the generic transaction form.