### PR TITLE
Close modals on mobile back button instead of navigating away

### DIFF
--- a/packages/hub/src/components/MobileSelectSheet.test.tsx
+++ b/packages/hub/src/components/MobileSelectSheet.test.tsx
@@ -50,4 +50,11 @@ describe('MobileSelectSheet', () => {
     fireEvent.change(screen.getByRole('textbox'), { target: { value: 'xyz' } });
     expect(screen.getByText('No options found')).toBeTruthy();
   });
+
+  it('calls onClose when the browser back button is pressed', () => {
+    const onClose = vi.fn();
+    render(<MobileSelectSheet options={options} onChange={vi.fn()} onClose={onClose} />);
+    window.dispatchEvent(new PopStateEvent('popstate'));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
 });

--- a/packages/hub/src/components/MobileSelectSheet.tsx
+++ b/packages/hub/src/components/MobileSelectSheet.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { cn } from '@/lib/utils';
 import { usePortalTheme } from '@/hooks/usePortalTheme';
+import { useCloseOnBackButton } from '@/hooks/useCloseOnBackButton';
 import { Button } from '@/components/Button';
 import { IconButton } from '@/components/IconButton';
 import { Input } from '@/components/Input';
@@ -65,6 +66,8 @@ export function MobileSelectSheet({
   const overlayRef = useRef<HTMLDivElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
   const [themeAnchorRef, themeClassName] = usePortalTheme();
+
+  useCloseOnBackButton(onClose);
 
   useEffect(() => {
     if (!searchable) return;

--- a/packages/hub/src/components/Modal.test.tsx
+++ b/packages/hub/src/components/Modal.test.tsx
@@ -77,4 +77,29 @@ describe('Modal', () => {
     expect(shell).not.toBeNull();
     expect(shell!.closest('.opacity-50')).toBeNull();
   });
+
+  it('calls onClose when the browser back button is pressed', () => {
+    const onClose = vi.fn();
+    render(
+      <Modal title="Test" onClose={onClose}>
+        body
+      </Modal>,
+    );
+    window.dispatchEvent(new PopStateEvent('popstate'));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('discards its pushed history entry when closed without a back-press', () => {
+    const historyBackSpy = vi
+      .spyOn(window.history, 'back')
+      .mockImplementation(() => window.dispatchEvent(new PopStateEvent('popstate')));
+    const { unmount } = render(
+      <Modal title="Test" onClose={vi.fn()}>
+        body
+      </Modal>,
+    );
+    unmount();
+    expect(historyBackSpy).toHaveBeenCalledOnce();
+    historyBackSpy.mockRestore();
+  });
 });

--- a/packages/hub/src/components/Modal.tsx
+++ b/packages/hub/src/components/Modal.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import { cn } from '@/lib/utils';
 import { usePortalTheme } from '@/hooks/usePortalTheme';
+import { useCloseOnBackButton } from '@/hooks/useCloseOnBackButton';
 import { Button } from '@/components/Button';
 import { IconButton } from '@/components/IconButton';
 import { XOutlineIcon } from '@/components/icons/XOutlineIcon';
@@ -47,6 +48,8 @@ export function Modal({
 }: ModalProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [themeAnchorRef, themeClassName] = usePortalTheme();
+
+  useCloseOnBackButton(onClose);
 
   useEffect(() => {
     const prev = document.body.style.overflow;

--- a/packages/hub/src/hooks/useCloseOnBackButton.test.ts
+++ b/packages/hub/src/hooks/useCloseOnBackButton.test.ts
@@ -1,0 +1,58 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useCloseOnBackButton } from './useCloseOnBackButton';
+
+function back() {
+  window.dispatchEvent(new PopStateEvent('popstate'));
+}
+
+describe('useCloseOnBackButton', () => {
+  afterEach(() => {
+    window.history.replaceState(null, '', window.location.href);
+  });
+
+  it('pushes a history entry on mount', () => {
+    const before = window.history.length;
+    renderHook(() => useCloseOnBackButton(vi.fn()));
+    expect(window.history.length).toBe(before + 1);
+  });
+
+  it('calls onClose when the browser back button is pressed', () => {
+    const onClose = vi.fn();
+    renderHook(() => useCloseOnBackButton(onClose));
+    act(() => back());
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('discards the pushed history entry when closed without a back-press', () => {
+    const historyBackSpy = vi.spyOn(window.history, 'back').mockImplementation(() => back());
+    const { unmount } = renderHook(() => useCloseOnBackButton(vi.fn()));
+    unmount();
+    expect(historyBackSpy).toHaveBeenCalledOnce();
+    historyBackSpy.mockRestore();
+  });
+
+  it('does not call history.back again if already closed via a back-press', () => {
+    const historyBackSpy = vi.spyOn(window.history, 'back');
+    const onClose = vi.fn();
+    const { unmount } = renderHook(() => useCloseOnBackButton(onClose));
+    act(() => back());
+    unmount();
+    expect(historyBackSpy).not.toHaveBeenCalled();
+    historyBackSpy.mockRestore();
+  });
+
+  it('only closes the topmost of two nested overlays on one back-press', () => {
+    const outerClose = vi.fn();
+    const innerClose = vi.fn();
+    renderHook(() => useCloseOnBackButton(outerClose));
+    renderHook(() => useCloseOnBackButton(innerClose));
+
+    act(() => back());
+    expect(innerClose).toHaveBeenCalledOnce();
+    expect(outerClose).not.toHaveBeenCalled();
+
+    act(() => back());
+    expect(outerClose).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/hub/src/hooks/useCloseOnBackButton.ts
+++ b/packages/hub/src/hooks/useCloseOnBackButton.ts
@@ -1,0 +1,48 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * Module-level LIFO stack of currently-open overlays' close callbacks, shared by every
+ * `useCloseOnBackButton` instance. Overlays can nest (e.g. a `MobileSelectSheet` opened from
+ * inside an already-open `Modal`), and each holds its own history entry — a single shared
+ * `popstate` listener (rather than one per overlay) ensures one back-press closes only the
+ * topmost overlay instead of every open overlay firing at once.
+ */
+const stack: Array<() => void> = [];
+
+function handlePopState() {
+  const onClose = stack.pop();
+  onClose?.();
+}
+
+function subscribe(onClose: () => void) {
+  if (stack.length === 0) window.addEventListener('popstate', handlePopState);
+  stack.push(onClose);
+}
+
+function unsubscribe(onClose: () => void) {
+  const index = stack.lastIndexOf(onClose);
+  if (index === -1) return; // already popped by a popstate back-press
+  stack.splice(index, 1);
+  if (stack.length === 0) window.removeEventListener('popstate', handlePopState);
+  // Closed via UI (X/Cancel/backdrop/save), not a back-press — discard the synthetic history
+  // entry pushed on mount so a second real back-press isn't needed to leave the page.
+  window.history.back();
+}
+
+/**
+ * Makes the mobile/browser back button close an open overlay (modal, sheet) instead of
+ * navigating away from the page. Pushes a synthetic history entry on mount (same URL, so
+ * Next.js's router sees no URL change and does nothing) and pops it on unmount. A back-press
+ * fires `popstate`, which closes the topmost open overlay via the shared stack above.
+ */
+export function useCloseOnBackButton(onClose: () => void): void {
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+
+  useEffect(() => {
+    const close = () => onCloseRef.current();
+    window.history.pushState({ ...window.history.state, hubOverlay: true }, '', window.location.href);
+    subscribe(close);
+    return () => unsubscribe(close);
+  }, []);
+}


### PR DESCRIPTION
Add a shared useCloseOnBackButton hook that pushes a synthetic history
entry when Modal/MobileSelectSheet open and closes the topmost overlay
on a popstate (back-press) instead of leaving the page. A module-level
LIFO stack ensures nested overlays (e.g. a select sheet opened from
inside a modal) only close one at a time.