### PR TITLE
Animate the "Log it" click on the Next Planned Meal card

### DIFF
--- a/packages/hub/src/app/calories/NextMealCard.tsx
+++ b/packages/hub/src/app/calories/NextMealCard.tsx
@@ -3,9 +3,9 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
 import type { z } from 'zod';
-import { apiFetch } from '@/lib/utils';
+import { apiFetch, cn } from '@/lib/utils';
 import { Button } from '@/components';
-import { UtensilsOutlineIcon } from '@/components/icons';
+import { AnimatedCheckIcon, UtensilsOutlineIcon } from '@/components/icons';
 import { TodayPlanResponseSchema } from '@/app/api/calories/menu/menu.schemas';
 import { mealOrder } from '@my-hub/shared/utils';
 import type { GymTime } from '@my-hub/shared/constants';
@@ -20,6 +20,10 @@ type NextMealCardProps = {
   date: string;
 };
 
+// How long the drawn checkmark stays up before the card swaps to the next meal. Long enough
+// that the draw animation (~480ms incl. its start delay) is fully visible even on a fast network.
+const CHECK_HOLD_MS = 600;
+
 /**
  * What the weekly menu says you eat next, surfaced on the page you actually land on. Without it
  * the plan lives only inside the Weekly Menu tab: you have to go looking for it, on a screen
@@ -33,6 +37,11 @@ export function NextMealCard({ date }: NextMealCardProps) {
   const [menuId, setMenuId] = useState<string | null>(null);
   const [gymTime, setGymTime] = useState<GymTime | null>(null);
   const [logging, setLogging] = useState(false);
+  // The just-logged meal's display info, frozen for the checkmark hold so the card doesn't
+  // jump to the next meal before the "logged" animation has had a chance to play.
+  const [frozen, setFrozen] = useState<{ meal: PlannedMeal; remaining: number } | null>(null);
+  // Bumped once the hold ends, so the swap-in animation on the content block replays via `key`.
+  const [animKey, setAnimKey] = useState(0);
 
   // The date this component is currently showing. Two rapid clicks on the date arrows leave two
   // requests in flight, and without this the slower one wins — the card would show one day's plan
@@ -71,20 +80,30 @@ export function NextMealCard({ date }: NextMealCardProps) {
     return () => mealEvents.off('changed', load);
   }, [load]);
 
-  if (!menuId || meals.length === 0) return null;
+  if (!frozen && (!menuId || meals.length === 0)) return null;
 
   const order = mealOrder(gymTime);
   const ordered = [...meals].sort((a, b) => order.indexOf(a.mealType) - order.indexOf(b.mealType));
   const next = ordered.find(m => !m.logged);
   const remaining = ordered.filter(m => !m.logged).length;
 
+  // While `frozen` is set, keep showing the meal that was just logged (and its remaining count
+  // as it was before logging) so the checkmark animation isn't cut short by a background refetch.
+  const meal = frozen?.meal ?? next;
+  const displayRemaining = frozen?.remaining ?? remaining;
+
   // Takes the id as an argument: the `!menuId` guard above narrows the render body, but a closure
   // defined after it is still typed against the widened state.
-  async function logNext(id: string, meal: PlannedMeal) {
+  async function logNext(id: string, loggedMeal: PlannedMeal, remainingAtClick: number) {
     setLogging(true);
     try {
-      await setMealLogged(id, date, meal.dayOfWeek, meal, true, { silentToast: true });
+      await setMealLogged(id, date, loggedMeal.dayOfWeek, loggedMeal, true, { silentToast: true });
       mealEvents.emit('changed');
+      setLogging(false);
+      setFrozen({ meal: loggedMeal, remaining: remainingAtClick });
+      await new Promise(resolve => setTimeout(resolve, CHECK_HOLD_MS));
+      setFrozen(null);
+      setAnimKey(k => k + 1);
     } finally {
       setLogging(false);
     }
@@ -95,41 +114,49 @@ export function NextMealCard({ date }: NextMealCardProps) {
       <div className="flex items-center justify-between gap-2">
         <span className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-widest text-[var(--accent)]">
           <UtensilsOutlineIcon className="size-3.5" />
-          {next ? 'Next planned meal' : "Today's plan"}
+          {meal ? 'Next planned meal' : "Today's plan"}
         </span>
         <Link href="/calories/menu" className="text-[11px] text-[var(--subtle)] hover:text-[var(--accent)]">
           Weekly menu →
         </Link>
       </div>
 
-      {next ? (
-        <div className="flex items-end justify-between gap-3">
-          <div className="min-w-0">
-            <p className="text-[10px] uppercase tracking-wide font-semibold text-[var(--muted)]">
-              {MEAL_LABEL[next.mealType]}
-            </p>
-            <p className="text-sm text-[var(--text)] leading-snug">{next.description}</p>
-            {next.kcal != null && (
-              <p className="text-[10px] text-[var(--subtle)] mt-0.5">
-                {next.kcal} kcal
-                {remaining > 1 && ` · ${remaining - 1} more planned today`}
+      <div key={animKey} className={cn(!frozen && 'animate-[fadeScaleIn_260ms_ease-out]')}>
+        {meal ? (
+          <div className="flex items-end justify-between gap-3">
+            <div className="min-w-0">
+              <p className="text-[10px] uppercase tracking-wide font-semibold text-[var(--muted)]">
+                {MEAL_LABEL[meal.mealType]}
               </p>
-            )}
+              <p className="text-sm text-[var(--text)] leading-snug">{meal.description}</p>
+              {meal.kcal != null && (
+                <p className="text-[10px] text-[var(--subtle)] mt-0.5">
+                  {meal.kcal} kcal
+                  {displayRemaining > 1 && ` · ${displayRemaining - 1} more planned today`}
+                </p>
+              )}
+            </div>
+            {frozen ? (
+              <span className="shrink-0 flex items-center justify-center size-8 rounded-full bg-[var(--accent)]/15 text-[var(--accent)] animate-[fadeScaleIn_200ms_ease-out]">
+                <AnimatedCheckIcon className="size-4" />
+              </span>
+            ) : next && menuId ? (
+              <Button
+                type="button"
+                variant="accent"
+                size="sm"
+                loading={logging}
+                onClick={() => void logNext(menuId, next, remaining)}
+                className="shrink-0 px-3 py-1.5 text-xs"
+              >
+                Log it
+              </Button>
+            ) : null}
           </div>
-          <Button
-            type="button"
-            variant="accent"
-            size="sm"
-            loading={logging}
-            onClick={() => void logNext(menuId, next)}
-            className="shrink-0 px-3 py-1.5 text-xs"
-          >
-            Log it
-          </Button>
-        </div>
-      ) : (
-        <p className="text-sm text-green-400">✓ Everything planned for today is logged.</p>
-      )}
+        ) : (
+          <p className="text-sm text-green-400">✓ Everything planned for today is logged.</p>
+        )}
+      </div>
     </div>
   );
 }

--- a/packages/hub/src/components/icons/AnimatedCheckIcon.tsx
+++ b/packages/hub/src/components/icons/AnimatedCheckIcon.tsx
@@ -1,0 +1,21 @@
+import { cn } from '@/lib/utils';
+import { IconProps } from './types';
+
+export function AnimatedCheckIcon({ className }: IconProps = {}) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" className={cn('size-5', className)} aria-hidden="true">
+      <circle cx="12" cy="12" r="11" className="stroke-current opacity-30" strokeWidth="1.5" />
+      <polyline
+        points="7 12.5 10.5 16 17 8"
+        stroke="currentColor"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        pathLength={1}
+        strokeDasharray={1}
+        strokeDashoffset={1}
+        className="animate-[checkDraw_380ms_ease-out_100ms_forwards]"
+      />
+    </svg>
+  );
+}

--- a/packages/hub/src/components/icons/index.ts
+++ b/packages/hub/src/components/icons/index.ts
@@ -35,6 +35,7 @@ export { PlaneOutlineIcon } from './PlaneOutlineIcon';
 export { ServerOutlineIcon } from './ServerOutlineIcon';
 export { UserPlusOutlineIcon } from './UserPlusOutlineIcon';
 export { CheckOutlineIcon } from './CheckOutlineIcon';
+export { AnimatedCheckIcon } from './AnimatedCheckIcon';
 export { TrashOutlineIcon } from './TrashOutlineIcon';
 export { SpinnerIcon } from './SpinnerIcon';
 export { EyeOutlineIcon } from './EyeOutlineIcon';

--- a/packages/hub/src/styles/globals.css
+++ b/packages/hub/src/styles/globals.css
@@ -49,6 +49,15 @@
   }
 }
 
+@keyframes checkDraw {
+  from {
+    stroke-dashoffset: 1;
+  }
+  to {
+    stroke-dashoffset: 0;
+  }
+}
+
 /* Mobile: full-screen shell slides up */
 .modal-shell {
   animation: slideUpSheet 320ms cubic-bezier(0.32, 0.72, 0, 1);


### PR DESCRIPTION
Logging a meal used to swap the card content instantly, making the
change to the next planned meal easy to miss. The button is now
replaced by a checkmark that draws itself in, held briefly, then the
card content fades/scales into the next meal (or the "all logged"
message).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01V7n3NZ5vvRfeFKjiQNxJfZ