### PR TITLE
Redesign mobile calendar cells with macro breakdown and bigger status icon

### DIFF
--- a/packages/hub/src/app/calories/MacroChart.tsx
+++ b/packages/hub/src/app/calories/MacroChart.tsx
@@ -3,7 +3,7 @@
 import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip } from 'recharts';
 import { Card } from '@/components';
 import { MACRO_COLORS } from './constants';
-import { macroCalorieSplit } from './calories.utils';
+import { macroCalorieSplit, pctOfTotal } from './calories.utils';
 
 interface Props {
   protein: number;
@@ -27,7 +27,7 @@ export function MacroChart({ protein, carbs, fat, goalProtein, goalCarbs, goalFa
     { name: 'Fat', value: fatCal, grams: fat, goal: goalFat, color: MACRO_COLORS.fat },
   ];
 
-  const pct = (val: number) => (total > 0 ? Math.round((val / total) * 100) : 0);
+  const pct = (val: number) => pctOfTotal(val, total);
 
   return (
     <Card className="p-5" compact={compact}>

--- a/packages/hub/src/app/calories/calendar/DayCell.tsx
+++ b/packages/hub/src/app/calories/calendar/DayCell.tsx
@@ -1,13 +1,13 @@
 'use client';
 
 import { cn } from '@/lib/utils';
-import { intakeBarColor, macroCalorieSplit } from '../calories.utils';
+import { intakeBarColor, macroCalorieSplit, pctOfTotal } from '../calories.utils';
 import { MACRO_COLORS } from '../constants';
 import { MenuStatusBadge } from './MenuStatusBadge';
 import { MenuStatusIcon } from './MenuStatusIcon';
 import { menuDayStatus } from './calendar.utils';
 import type { CalendarDay } from './types';
-import type { MonthGridDay } from './calendar.utils';
+import type { DayRelation, MonthGridDay } from './calendar.utils';
 
 type DayCellProps = {
   day: MonthGridDay;
@@ -37,37 +37,38 @@ export function DayCell({ day, summary, isToday, isPast, onSelect }: DayCellProp
     fatCal,
     total: macroTotal,
   } = macroCalorieSplit(summary?.protein ?? 0, summary?.carbs ?? 0, summary?.fat ?? 0);
-  const status = menuDayStatus(summary?.hasMenu ?? false, summary?.menuLogged ?? false, isPast, isToday);
-  const macroPct = (cal: number) => (macroTotal > 0 ? Math.round((cal / macroTotal) * 100) : 0);
+  // A single derived relation instead of passing isPast/isToday through separately — the pair
+  // can't both be true, but nothing enforces that at the call site, so menuDayStatus takes one
+  // value with the invalid combination made unrepresentable.
+  const dayRelation: DayRelation = isToday ? 'today' : isPast ? 'past' : 'future';
+  const status = menuDayStatus(summary?.hasMenu ?? false, summary?.menuLogged ?? false, dayRelation);
 
   const cellStyle =
     day.inMonth && hasData
       ? { backgroundColor: `color-mix(in srgb, ${color} 16%, var(--card2))`, borderColor: color }
       : undefined;
 
-  const baseClasses = cn(
-    'relative flex flex-col items-center rounded-lg border text-center transition-colors',
-    day.inMonth ? 'border-[var(--border)] bg-[var(--card2)]' : 'border-transparent bg-transparent opacity-40',
-    isToday && 'border-[var(--accent)]',
-    'hover:border-[var(--accent)]/60',
-  );
-
-  const dayNumLabel = (
-    <span className={cn('text-[10px]', day.inMonth ? 'text-[var(--muted)]' : 'text-[var(--subtle)]')}>{dayNum}</span>
-  );
-
   return (
-    <>
+    <button
+      type="button"
+      onClick={() => onSelect(day.date)}
+      className={cn(
+        'relative flex flex-col items-center rounded-lg border text-center transition-colors',
+        day.inMonth ? 'border-[var(--border)] bg-[var(--card2)]' : 'border-transparent bg-transparent opacity-40',
+        isToday && 'border-[var(--accent)]',
+        'hover:border-[var(--accent)]/60',
+      )}
+      style={cellStyle}
+    >
       {/* Desktop: compact square cell — day number, kcal, thin macro bar, corner menu badge. */}
-      <button
-        type="button"
+      <div
         data-layout="desktop"
-        onClick={() => onSelect(day.date)}
-        className={cn(baseClasses, 'hidden aspect-square justify-center gap-0.5 md:flex')}
-        style={cellStyle}
+        className="hidden aspect-square w-full flex-col items-center justify-center gap-0.5 md:flex"
       >
         {day.inMonth && <MenuStatusBadge status={status} />}
-        {dayNumLabel}
+        <span className={cn('text-[10px]', day.inMonth ? 'text-[var(--muted)]' : 'text-[var(--subtle)]')}>
+          {dayNum}
+        </span>
         {day.inMonth && hasData && (
           <span className="text-[11px] font-semibold" style={{ color }}>
             {Math.round(kcal)}
@@ -80,18 +81,17 @@ export function DayCell({ day, summary, isToday, isPast, onSelect }: DayCellProp
             <div style={{ width: `${(fatCal / macroTotal) * 100}%`, backgroundColor: MACRO_COLORS.fat }} />
           </div>
         )}
-      </button>
+      </div>
 
       {/* Mobile: taller cell with room for a per-macro percentage line each and a bigger status
           icon anchored to the bottom, instead of a tiny corner badge. */}
-      <button
-        type="button"
+      <div
         data-layout="mobile"
-        onClick={() => onSelect(day.date)}
-        className={cn(baseClasses, 'flex aspect-[3/4] justify-between gap-0.5 py-1.5 md:hidden')}
-        style={cellStyle}
+        className="flex aspect-[3/4] w-full flex-col items-center justify-between gap-0.5 py-1.5 md:hidden"
       >
-        {dayNumLabel}
+        <span className={cn('text-[10px]', day.inMonth ? 'text-[var(--muted)]' : 'text-[var(--subtle)]')}>
+          {dayNum}
+        </span>
 
         {day.inMonth && hasData && (
           <div className="flex flex-col items-center gap-0.5">
@@ -101,13 +101,13 @@ export function DayCell({ day, summary, isToday, isPast, onSelect }: DayCellProp
             {macroTotal > 0 && (
               <div className="flex flex-col items-center gap-px leading-none">
                 <span className="text-[9px] font-medium" style={{ color: MACRO_COLORS.protein }}>
-                  P {macroPct(proteinCal)}%
+                  P {pctOfTotal(proteinCal, macroTotal)}%
                 </span>
                 <span className="text-[9px] font-medium" style={{ color: MACRO_COLORS.carbs }}>
-                  C {macroPct(carbsCal)}%
+                  C {pctOfTotal(carbsCal, macroTotal)}%
                 </span>
                 <span className="text-[9px] font-medium" style={{ color: MACRO_COLORS.fat }}>
-                  F {macroPct(fatCal)}%
+                  F {pctOfTotal(fatCal, macroTotal)}%
                 </span>
               </div>
             )}
@@ -115,7 +115,7 @@ export function DayCell({ day, summary, isToday, isPast, onSelect }: DayCellProp
         )}
 
         {day.inMonth && <MenuStatusIcon status={status} className="mt-auto" />}
-      </button>
-    </>
+      </div>
+    </button>
   );
 }

--- a/packages/hub/src/app/calories/calendar/DayCell.tsx
+++ b/packages/hub/src/app/calories/calendar/DayCell.tsx
@@ -4,6 +4,7 @@ import { cn } from '@/lib/utils';
 import { intakeBarColor, macroCalorieSplit } from '../calories.utils';
 import { MACRO_COLORS } from '../constants';
 import { MenuStatusBadge } from './MenuStatusBadge';
+import { MenuStatusIcon } from './MenuStatusIcon';
 import { menuDayStatus } from './calendar.utils';
 import type { CalendarDay } from './types';
 import type { MonthGridDay } from './calendar.utils';
@@ -20,6 +21,10 @@ type DayCellProps = {
  * One month-grid cell: the day number and, once meals are logged, the kcal total tinted by the
  * same red/amber/green adherence rule the weekly menu and progress bars use — a day reads the
  * same way whichever tab it's judged from.
+ *
+ * Desktop and mobile render genuinely different layouts rather than the same content resized: a
+ * square desktop cell only has room for a thin macro bar and a small corner badge, while a taller
+ * mobile cell has room for a per-macro percentage line each and a bigger status icon.
  */
 export function DayCell({ day, summary, isToday, isPast, onSelect }: DayCellProps) {
   const kcal = summary?.kcal ?? 0;
@@ -32,38 +37,85 @@ export function DayCell({ day, summary, isToday, isPast, onSelect }: DayCellProp
     fatCal,
     total: macroTotal,
   } = macroCalorieSplit(summary?.protein ?? 0, summary?.carbs ?? 0, summary?.fat ?? 0);
-  const status = menuDayStatus(summary?.hasMenu ?? false, summary?.menuLogged ?? false, isPast);
+  const status = menuDayStatus(summary?.hasMenu ?? false, summary?.menuLogged ?? false, isPast, isToday);
+  const macroPct = (cal: number) => (macroTotal > 0 ? Math.round((cal / macroTotal) * 100) : 0);
+
+  const cellStyle =
+    day.inMonth && hasData
+      ? { backgroundColor: `color-mix(in srgb, ${color} 16%, var(--card2))`, borderColor: color }
+      : undefined;
+
+  const baseClasses = cn(
+    'relative flex flex-col items-center rounded-lg border text-center transition-colors',
+    day.inMonth ? 'border-[var(--border)] bg-[var(--card2)]' : 'border-transparent bg-transparent opacity-40',
+    isToday && 'border-[var(--accent)]',
+    'hover:border-[var(--accent)]/60',
+  );
+
+  const dayNumLabel = (
+    <span className={cn('text-[10px]', day.inMonth ? 'text-[var(--muted)]' : 'text-[var(--subtle)]')}>{dayNum}</span>
+  );
 
   return (
-    <button
-      type="button"
-      onClick={() => onSelect(day.date)}
-      className={cn(
-        'relative flex aspect-square flex-col items-center justify-center gap-0.5 rounded-lg border text-center transition-colors',
-        day.inMonth ? 'border-[var(--border)] bg-[var(--card2)]' : 'border-transparent bg-transparent opacity-40',
-        isToday && 'border-[var(--accent)]',
-        'hover:border-[var(--accent)]/60',
-      )}
-      style={
-        day.inMonth && hasData
-          ? { backgroundColor: `color-mix(in srgb, ${color} 16%, var(--card2))`, borderColor: color }
-          : undefined
-      }
-    >
-      {day.inMonth && <MenuStatusBadge status={status} />}
-      <span className={cn('text-[10px]', day.inMonth ? 'text-[var(--muted)]' : 'text-[var(--subtle)]')}>{dayNum}</span>
-      {day.inMonth && hasData && (
-        <span className="text-[11px] font-semibold" style={{ color }}>
-          {Math.round(kcal)}
-        </span>
-      )}
-      {day.inMonth && hasData && macroTotal > 0 && (
-        <div className="flex h-[3px] w-3/4 max-w-[28px] overflow-hidden rounded-full">
-          <div style={{ width: `${(proteinCal / macroTotal) * 100}%`, backgroundColor: MACRO_COLORS.protein }} />
-          <div style={{ width: `${(carbsCal / macroTotal) * 100}%`, backgroundColor: MACRO_COLORS.carbs }} />
-          <div style={{ width: `${(fatCal / macroTotal) * 100}%`, backgroundColor: MACRO_COLORS.fat }} />
-        </div>
-      )}
-    </button>
+    <>
+      {/* Desktop: compact square cell — day number, kcal, thin macro bar, corner menu badge. */}
+      <button
+        type="button"
+        data-layout="desktop"
+        onClick={() => onSelect(day.date)}
+        className={cn(baseClasses, 'hidden aspect-square justify-center gap-0.5 md:flex')}
+        style={cellStyle}
+      >
+        {day.inMonth && <MenuStatusBadge status={status} />}
+        {dayNumLabel}
+        {day.inMonth && hasData && (
+          <span className="text-[11px] font-semibold" style={{ color }}>
+            {Math.round(kcal)}
+          </span>
+        )}
+        {day.inMonth && hasData && macroTotal > 0 && (
+          <div className="flex h-[3px] w-3/4 max-w-[28px] overflow-hidden rounded-full">
+            <div style={{ width: `${(proteinCal / macroTotal) * 100}%`, backgroundColor: MACRO_COLORS.protein }} />
+            <div style={{ width: `${(carbsCal / macroTotal) * 100}%`, backgroundColor: MACRO_COLORS.carbs }} />
+            <div style={{ width: `${(fatCal / macroTotal) * 100}%`, backgroundColor: MACRO_COLORS.fat }} />
+          </div>
+        )}
+      </button>
+
+      {/* Mobile: taller cell with room for a per-macro percentage line each and a bigger status
+          icon anchored to the bottom, instead of a tiny corner badge. */}
+      <button
+        type="button"
+        data-layout="mobile"
+        onClick={() => onSelect(day.date)}
+        className={cn(baseClasses, 'flex aspect-[3/4] justify-between gap-0.5 py-1.5 md:hidden')}
+        style={cellStyle}
+      >
+        {dayNumLabel}
+
+        {day.inMonth && hasData && (
+          <div className="flex flex-col items-center gap-0.5">
+            <span className="text-xs font-semibold leading-none" style={{ color }}>
+              {Math.round(kcal)}
+            </span>
+            {macroTotal > 0 && (
+              <div className="flex flex-col items-center gap-px leading-none">
+                <span className="text-[9px] font-medium" style={{ color: MACRO_COLORS.protein }}>
+                  P {macroPct(proteinCal)}%
+                </span>
+                <span className="text-[9px] font-medium" style={{ color: MACRO_COLORS.carbs }}>
+                  C {macroPct(carbsCal)}%
+                </span>
+                <span className="text-[9px] font-medium" style={{ color: MACRO_COLORS.fat }}>
+                  F {macroPct(fatCal)}%
+                </span>
+              </div>
+            )}
+          </div>
+        )}
+
+        {day.inMonth && <MenuStatusIcon status={status} className="mt-auto" />}
+      </button>
+    </>
   );
 }

--- a/packages/hub/src/app/calories/calendar/DayDetailModal.tsx
+++ b/packages/hub/src/app/calories/calendar/DayDetailModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { apiFetch } from '@/lib/utils';
 import { Modal } from '@/components';
 import type { CalorieProfile, MealLog } from '@my-hub/shared/types';
@@ -39,8 +39,24 @@ export function DayDetailModal({ date, summary, onClose }: DayDetailModalProps) 
   const [gymTime, setGymTime] = useState<GymTime | null>(null);
   const [profile, setProfile] = useState<CalorieProfile | null>(null);
   const [loading, setLoading] = useState(true);
+  // Bumped after a mutation inside the modal (log/edit/delete via MealRow) to re-run the
+  // day-scoped fetch below without needing a stable function identity to key an effect on.
+  const [reloadKey, setReloadKey] = useState(0);
 
-  const load = useCallback(() => {
+  // The profile (goals/macro targets) doesn't change when a meal is logged, so it's fetched once
+  // on mount rather than on every reload below — logging/editing/deleting a meal has no reason to
+  // re-request it.
+  useEffect(() => {
+    let cancelled = false;
+    apiFetch<{ profile: CalorieProfile | null }>('/api/calories/profile', { silentToast: true }).then(data => {
+      if (!cancelled) setProfile(data.profile);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
     let cancelled = false;
     setLoading(true);
     Promise.all([
@@ -49,15 +65,13 @@ export function DayDetailModal({ date, summary, onClose }: DayDetailModalProps) 
         query: { date },
         silentToast: true,
       }),
-      apiFetch<{ profile: CalorieProfile | null }>('/api/calories/profile', { silentToast: true }),
     ])
-      .then(([mealsData, planData, profileData]) => {
+      .then(([mealsData, planData]) => {
         if (cancelled) return;
         setMeals(mealsData.meals);
         setMenuId(planData.menuId);
         setPlannedMeals(planData.meals);
         setGymTime(planData.gymTime);
-        setProfile(profileData.profile);
       })
       .finally(() => {
         if (!cancelled) setLoading(false);
@@ -65,20 +79,19 @@ export function DayDetailModal({ date, summary, onClose }: DayDetailModalProps) 
     return () => {
       cancelled = true;
     };
-  }, [date]);
-
-  useEffect(() => load(), [load]);
+  }, [date, reloadKey]);
 
   /**
    * Logging/editing/deleting a planned meal here also touches the calorie journal (log-day
    * writes both in one transaction) and this day's kcal/macro totals, which the modal doesn't
-   * own — they come in as the `summary` prop from the month grid. Reloading the modal's own data
-   * and re-emitting `mealEvents` (the feature's cross-widget refresh signal) keeps both the
-   * "Logged" list here and the month grid's totals/badge in step with a single source of truth,
-   * instead of hand-patching local state to match what the server just did.
+   * own — they come in as the `summary` prop from the month grid. Bumping `reloadKey` (re-running
+   * the day-scoped fetch above) and re-emitting `mealEvents` (the feature's cross-widget refresh
+   * signal, which the month grid listens for) keeps both the "Logged" list here and the grid's
+   * totals/badge in step with a single source of truth, instead of hand-patching local state to
+   * match what the server just did.
    */
   function handleMealChanged() {
-    load();
+    setReloadKey(k => k + 1);
     mealEvents.emit('changed');
   }
 

--- a/packages/hub/src/app/calories/calendar/DayDetailModal.tsx
+++ b/packages/hub/src/app/calories/calendar/DayDetailModal.tsx
@@ -1,24 +1,22 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { apiFetch } from '@/lib/utils';
 import { Modal } from '@/components';
 import type { CalorieProfile, MealLog } from '@my-hub/shared/types';
 import type { MealType, GymTime } from '@my-hub/shared/constants';
-import { mealOrder } from '@my-hub/shared/utils';
+import { dateToString, mealOrder } from '@my-hub/shared/utils';
 import { MEAL_LABEL } from '../constants';
 import { formatDateLabel, groupByMealType } from '../calories.utils';
 import { targetPct, targetColorClasses } from '../menu/menu.utils';
 import { TargetBar } from '../menu/TargetBar';
 import { MacroChart } from '../MacroChart';
+import { MealRow } from '../menu/MealRow';
+import { mealEvents } from '../mealEvents';
+import type { WeeklyMenuMeal } from '../menu/types';
 import type { CalendarDay } from './types';
 
-type PlannedMeal = {
-  mealType: MealType;
-  description: string;
-  kcal: number | null;
-  logged: boolean;
-};
+type PlannedMeal = WeeklyMenuMeal & { logged: boolean };
 
 type DayDetailModalProps = {
   date: string;
@@ -27,15 +25,22 @@ type DayDetailModalProps = {
   onClose: () => void;
 };
 
-/** kcal + macros + logged/planned meals for one day, opened from a calendar cell. Read-only. */
+/**
+ * kcal + macros + logged/planned meals for one day, opened from a calendar cell. The logged
+ * section is a read-only summary of the calorie journal, but planned menu items reuse `MealRow` —
+ * the same row the Weekly Menu tab renders — so this modal gets log/edit/delete for free and
+ * never drifts from how a planned meal looks and behaves everywhere else.
+ */
 export function DayDetailModal({ date, summary, onClose }: DayDetailModalProps) {
+  const today = dateToString(new Date());
   const [meals, setMeals] = useState<MealLog[]>([]);
+  const [menuId, setMenuId] = useState<string | null>(null);
   const [plannedMeals, setPlannedMeals] = useState<PlannedMeal[]>([]);
   const [gymTime, setGymTime] = useState<GymTime | null>(null);
   const [profile, setProfile] = useState<CalorieProfile | null>(null);
   const [loading, setLoading] = useState(true);
 
-  useEffect(() => {
+  const load = useCallback(() => {
     let cancelled = false;
     setLoading(true);
     Promise.all([
@@ -49,6 +54,7 @@ export function DayDetailModal({ date, summary, onClose }: DayDetailModalProps) 
       .then(([mealsData, planData, profileData]) => {
         if (cancelled) return;
         setMeals(mealsData.meals);
+        setMenuId(planData.menuId);
         setPlannedMeals(planData.meals);
         setGymTime(planData.gymTime);
         setProfile(profileData.profile);
@@ -60,6 +66,21 @@ export function DayDetailModal({ date, summary, onClose }: DayDetailModalProps) 
       cancelled = true;
     };
   }, [date]);
+
+  useEffect(() => load(), [load]);
+
+  /**
+   * Logging/editing/deleting a planned meal here also touches the calorie journal (log-day
+   * writes both in one transaction) and this day's kcal/macro totals, which the modal doesn't
+   * own — they come in as the `summary` prop from the month grid. Reloading the modal's own data
+   * and re-emitting `mealEvents` (the feature's cross-widget refresh signal) keeps both the
+   * "Logged" list here and the month grid's totals/badge in step with a single source of truth,
+   * instead of hand-patching local state to match what the server just did.
+   */
+  function handleMealChanged() {
+    load();
+    mealEvents.emit('changed');
+  }
 
   const kcal = summary?.kcal ?? 0;
   const target = summary?.target ?? null;
@@ -133,24 +154,22 @@ export function DayDetailModal({ date, summary, onClose }: DayDetailModalProps) 
               </section>
             )}
 
-            {orderedPlanned.length > 0 && (
-              <section className="flex flex-col gap-1.5">
+            {orderedPlanned.length > 0 && menuId && (
+              <section className="flex flex-col gap-2">
                 <h3 className="text-[10px] font-semibold uppercase tracking-wide text-[var(--subtle)]">Planned menu</h3>
                 {orderedPlanned.map(meal => (
-                  <div
+                  <MealRow
                     key={meal.mealType}
-                    className="flex items-center justify-between rounded-lg border border-[var(--border)] bg-[var(--card2)] px-2.5 py-2 text-xs"
-                  >
-                    <div className="flex flex-col">
-                      <span className={meal.logged ? 'text-[var(--text)]' : 'text-[var(--muted)]'}>
-                        {meal.description}
-                      </span>
-                      <span className="text-[10px] text-[var(--subtle)]">{MEAL_LABEL[meal.mealType]}</span>
-                    </div>
-                    <span className={meal.logged ? 'text-[var(--green)]' : 'text-[var(--subtle)]'}>
-                      {meal.logged ? '✓ logged' : meal.kcal ? `${meal.kcal} kcal` : ''}
-                    </span>
-                  </div>
+                    meal={meal}
+                    menuId={menuId}
+                    dayOfWeek={meal.dayOfWeek}
+                    dayDate={date}
+                    today={today}
+                    logged={meal.logged}
+                    onLogChanged={handleMealChanged}
+                    onSwapped={handleMealChanged}
+                    onDeleted={handleMealChanged}
+                  />
                 ))}
               </section>
             )}

--- a/packages/hub/src/app/calories/calendar/MenuStatusBadge.tsx
+++ b/packages/hub/src/app/calories/calendar/MenuStatusBadge.tsx
@@ -10,8 +10,9 @@ type MenuStatusBadgeProps = {
 
 /**
  * Corner badge on a calendar day cell for that day's weekly-menu plan: a covered-dish icon alone
- * while the day still has time to be logged, a green check once every planned meal is logged, and
- * a red x once the day has passed with something unlogged. Renders nothing when no menu is planned.
+ * while the day still has time to be logged (`planned` or `pending`), a green check once every
+ * planned meal is logged, and a red x once the day has passed with something unlogged. Renders
+ * nothing when no menu is planned.
  */
 export function MenuStatusBadge({ status }: MenuStatusBadgeProps) {
   if (status === 'none') return null;
@@ -19,7 +20,7 @@ export function MenuStatusBadge({ status }: MenuStatusBadgeProps) {
   return (
     <span className="absolute top-0.5 right-0.5 text-[var(--subtle)]">
       <ClocheIcon className="size-3" />
-      {status !== 'planned' && (
+      {(status === 'logged' || status === 'missed') && (
         <span
           className={cn(
             'absolute -bottom-0.5 -right-0.5 flex size-2.5 items-center justify-center rounded-full',

--- a/packages/hub/src/app/calories/calendar/MenuStatusBadge.tsx
+++ b/packages/hub/src/app/calories/calendar/MenuStatusBadge.tsx
@@ -2,6 +2,7 @@
 
 import { cn } from '@/lib/utils';
 import { ClocheIcon, CheckOutlineIcon, XOutlineIcon } from '@/components/icons';
+import { menuStatusTone } from './calendar.utils';
 import type { MenuDayStatus } from './calendar.utils';
 
 type MenuStatusBadgeProps = {
@@ -11,23 +12,27 @@ type MenuStatusBadgeProps = {
 /**
  * Corner badge on a calendar day cell for that day's weekly-menu plan: a covered-dish icon alone
  * while the day still has time to be logged (`planned` or `pending`), a green check once every
- * planned meal is logged, and a red x once the day has passed with something unlogged. Renders
- * nothing when no menu is planned.
+ * planned meal is logged, and a red x once the day has passed with something unlogged. Color comes
+ * from the shared `menuStatusTone` mapping in `calendar.utils.ts`, so this and `MenuStatusIcon`
+ * can't drift on which color represents which state. Renders nothing when no menu is planned.
  */
 export function MenuStatusBadge({ status }: MenuStatusBadgeProps) {
   if (status === 'none') return null;
 
+  const tone = menuStatusTone(status);
+  const resolved = tone === 'success' || tone === 'danger';
+
   return (
     <span className="absolute top-0.5 right-0.5 text-[var(--subtle)]">
       <ClocheIcon className="size-3" />
-      {(status === 'logged' || status === 'missed') && (
+      {resolved && (
         <span
           className={cn(
             'absolute -bottom-0.5 -right-0.5 flex size-2.5 items-center justify-center rounded-full',
-            status === 'logged' ? 'bg-[var(--green)]' : 'bg-[var(--red)]',
+            tone === 'success' ? 'bg-[var(--green)]' : 'bg-[var(--red)]',
           )}
         >
-          {status === 'logged' ? (
+          {tone === 'success' ? (
             <CheckOutlineIcon className="size-1.5 text-[var(--card)]" />
           ) : (
             <XOutlineIcon className="size-1.5 text-[var(--card)]" />

--- a/packages/hub/src/app/calories/calendar/MenuStatusIcon.tsx
+++ b/packages/hub/src/app/calories/calendar/MenuStatusIcon.tsx
@@ -2,6 +2,7 @@
 
 import { cn } from '@/lib/utils';
 import { ClocheIcon, ClockOutlineIcon, CheckOutlineIcon, XOutlineIcon } from '@/components/icons';
+import { menuStatusTone } from './calendar.utils';
 import type { MenuDayStatus } from './calendar.utils';
 
 type MenuStatusIconProps = {
@@ -11,31 +12,34 @@ type MenuStatusIconProps = {
 
 /**
  * Bottom-of-cell menu status indicator for the taller mobile calendar grid — bigger and more
- * legible than the desktop corner badge, since a taller cell has the room for it. `pending`
- * (today, unlogged) renders as an amber clock rather than the bare cloche `planned` uses for a
- * future day, so today reads as "still time to log" rather than blending into an ordinary
- * planned day. Renders nothing when no menu is planned.
+ * legible than the desktop corner badge, since a taller cell has the room for it. Color comes
+ * from the shared `menuStatusTone` mapping in `calendar.utils.ts` (the same one `MenuStatusBadge`
+ * uses), so the two can't drift on which color represents which state. `pending` (today,
+ * unlogged) renders as an amber clock rather than the bare cloche `planned` uses for a future
+ * day, so today reads as "still time to log" rather than blending into an ordinary planned day.
+ * Renders nothing when no menu is planned.
  */
 export function MenuStatusIcon({ status, className }: MenuStatusIconProps) {
   if (status === 'none') return null;
 
-  if (status === 'logged') {
+  const tone = menuStatusTone(status);
+
+  if (tone === 'success' || tone === 'danger') {
+    const Icon = tone === 'success' ? CheckOutlineIcon : XOutlineIcon;
     return (
-      <span className={cn('flex size-4 items-center justify-center rounded-full bg-[var(--green)]', className)}>
-        <CheckOutlineIcon className="size-2.5 text-[var(--card)]" />
+      <span
+        className={cn(
+          'flex size-4 items-center justify-center rounded-full',
+          tone === 'success' ? 'bg-[var(--green)]' : 'bg-[var(--red)]',
+          className,
+        )}
+      >
+        <Icon className="size-2.5 text-[var(--card)]" />
       </span>
     );
   }
 
-  if (status === 'missed') {
-    return (
-      <span className={cn('flex size-4 items-center justify-center rounded-full bg-[var(--red)]', className)}>
-        <XOutlineIcon className="size-2.5 text-[var(--card)]" />
-      </span>
-    );
-  }
-
-  if (status === 'pending') {
+  if (tone === 'accent') {
     return <ClockOutlineIcon className={cn('size-4 text-[var(--accent)]', className)} />;
   }
 

--- a/packages/hub/src/app/calories/calendar/MenuStatusIcon.tsx
+++ b/packages/hub/src/app/calories/calendar/MenuStatusIcon.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { cn } from '@/lib/utils';
+import { ClocheIcon, ClockOutlineIcon, CheckOutlineIcon, XOutlineIcon } from '@/components/icons';
+import type { MenuDayStatus } from './calendar.utils';
+
+type MenuStatusIconProps = {
+  status: MenuDayStatus;
+  className?: string;
+};
+
+/**
+ * Bottom-of-cell menu status indicator for the taller mobile calendar grid — bigger and more
+ * legible than the desktop corner badge, since a taller cell has the room for it. `pending`
+ * (today, unlogged) renders as an amber clock rather than the bare cloche `planned` uses for a
+ * future day, so today reads as "still time to log" rather than blending into an ordinary
+ * planned day. Renders nothing when no menu is planned.
+ */
+export function MenuStatusIcon({ status, className }: MenuStatusIconProps) {
+  if (status === 'none') return null;
+
+  if (status === 'logged') {
+    return (
+      <span className={cn('flex size-4 items-center justify-center rounded-full bg-[var(--green)]', className)}>
+        <CheckOutlineIcon className="size-2.5 text-[var(--card)]" />
+      </span>
+    );
+  }
+
+  if (status === 'missed') {
+    return (
+      <span className={cn('flex size-4 items-center justify-center rounded-full bg-[var(--red)]', className)}>
+        <XOutlineIcon className="size-2.5 text-[var(--card)]" />
+      </span>
+    );
+  }
+
+  if (status === 'pending') {
+    return <ClockOutlineIcon className={cn('size-4 text-[var(--accent)]', className)} />;
+  }
+
+  return <ClocheIcon className={cn('size-4 text-[var(--subtle)]', className)} />;
+}

--- a/packages/hub/src/app/calories/calendar/calendar.utils.test.ts
+++ b/packages/hub/src/app/calories/calendar/calendar.utils.test.ts
@@ -34,26 +34,26 @@ describe('buildMonthGridDays', () => {
 });
 
 describe('menuDayStatus', () => {
-  it('is "none" when no menu is planned, regardless of logged/past', () => {
-    expect(menuDayStatus(false, false, false, false)).toBe('none');
-    expect(menuDayStatus(false, true, true, false)).toBe('none');
+  it('is "none" when no menu is planned, regardless of logged/day relation', () => {
+    expect(menuDayStatus(false, false, 'future')).toBe('none');
+    expect(menuDayStatus(false, true, 'past')).toBe('none');
   });
 
   it('is "logged" when the day has a menu and it has all been logged', () => {
-    expect(menuDayStatus(true, true, false, false)).toBe('logged');
-    expect(menuDayStatus(true, true, true, false)).toBe('logged');
-    expect(menuDayStatus(true, true, false, true)).toBe('logged');
+    expect(menuDayStatus(true, true, 'future')).toBe('logged');
+    expect(menuDayStatus(true, true, 'past')).toBe('logged');
+    expect(menuDayStatus(true, true, 'today')).toBe('logged');
   });
 
   it('is "missed" when the day has passed with something planned left unlogged', () => {
-    expect(menuDayStatus(true, false, true, false)).toBe('missed');
+    expect(menuDayStatus(true, false, 'past')).toBe('missed');
   });
 
   it('is "pending" — never "missed" — for an unlogged menu on today, since the day isn\'t over', () => {
-    expect(menuDayStatus(true, false, false, true)).toBe('pending');
+    expect(menuDayStatus(true, false, 'today')).toBe('pending');
   });
 
   it('is "planned" for an unlogged menu on a future day', () => {
-    expect(menuDayStatus(true, false, false, false)).toBe('planned');
+    expect(menuDayStatus(true, false, 'future')).toBe('planned');
   });
 });

--- a/packages/hub/src/app/calories/calendar/calendar.utils.test.ts
+++ b/packages/hub/src/app/calories/calendar/calendar.utils.test.ts
@@ -35,20 +35,25 @@ describe('buildMonthGridDays', () => {
 
 describe('menuDayStatus', () => {
   it('is "none" when no menu is planned, regardless of logged/past', () => {
-    expect(menuDayStatus(false, false, false)).toBe('none');
-    expect(menuDayStatus(false, true, true)).toBe('none');
+    expect(menuDayStatus(false, false, false, false)).toBe('none');
+    expect(menuDayStatus(false, true, true, false)).toBe('none');
   });
 
   it('is "logged" when the day has a menu and it has all been logged', () => {
-    expect(menuDayStatus(true, true, false)).toBe('logged');
-    expect(menuDayStatus(true, true, true)).toBe('logged');
+    expect(menuDayStatus(true, true, false, false)).toBe('logged');
+    expect(menuDayStatus(true, true, true, false)).toBe('logged');
+    expect(menuDayStatus(true, true, false, true)).toBe('logged');
   });
 
   it('is "missed" when the day has passed with something planned left unlogged', () => {
-    expect(menuDayStatus(true, false, true)).toBe('missed');
+    expect(menuDayStatus(true, false, true, false)).toBe('missed');
   });
 
-  it('is "planned" for an unlogged menu on today or a future day', () => {
-    expect(menuDayStatus(true, false, false)).toBe('planned');
+  it('is "pending" — never "missed" — for an unlogged menu on today, since the day isn\'t over', () => {
+    expect(menuDayStatus(true, false, false, true)).toBe('pending');
+  });
+
+  it('is "planned" for an unlogged menu on a future day', () => {
+    expect(menuDayStatus(true, false, false, false)).toBe('planned');
   });
 });

--- a/packages/hub/src/app/calories/calendar/calendar.utils.ts
+++ b/packages/hub/src/app/calories/calendar/calendar.utils.ts
@@ -37,16 +37,19 @@ export function buildMonthGridDays(month: string): MonthGridDay[] {
 /**
  * A day cell's weekly-menu badge state:
  * - `none` — no menu planned for the day, so no icon shows at all.
- * - `planned` — a menu is planned and the day hasn't passed unlogged yet; icon alone.
+ * - `planned` — a menu is planned for a future day; icon alone.
+ * - `pending` — a menu is planned for today and isn't fully logged yet; the day still has time
+ *   left, so this must never read as "missed" — more meals may still be logged later today.
  * - `logged` — every planned meal for the day has been logged; icon + green check.
  * - `missed` — the day is in the past and something planned was never logged; icon + red x.
  */
-export type MenuDayStatus = 'none' | 'planned' | 'logged' | 'missed';
+export type MenuDayStatus = 'none' | 'planned' | 'pending' | 'logged' | 'missed';
 
 /** Resolves a day cell's menu badge state from the calendar API's per-day menu flags. */
-export function menuDayStatus(hasMenu: boolean, logged: boolean, isPast: boolean): MenuDayStatus {
+export function menuDayStatus(hasMenu: boolean, logged: boolean, isPast: boolean, isToday: boolean): MenuDayStatus {
   if (!hasMenu) return 'none';
   if (logged) return 'logged';
   if (isPast) return 'missed';
+  if (isToday) return 'pending';
   return 'planned';
 }

--- a/packages/hub/src/app/calories/calendar/calendar.utils.ts
+++ b/packages/hub/src/app/calories/calendar/calendar.utils.ts
@@ -35,7 +35,13 @@ export function buildMonthGridDays(month: string): MonthGridDay[] {
 }
 
 /**
- * A day cell's weekly-menu badge state:
+ * Where a day sits relative to today — a single value rather than an `isPast`/`isToday` pair of
+ * booleans, so "both true" can't be passed in by mistake. Callers derive it once from comparing
+ * the day's date against today's.
+ */
+export type DayRelation = 'past' | 'today' | 'future';
+
+/** A day cell's weekly-menu badge state:
  * - `none` — no menu planned for the day, so no icon shows at all.
  * - `planned` — a menu is planned for a future day; icon alone.
  * - `pending` — a menu is planned for today and isn't fully logged yet; the day still has time
@@ -46,10 +52,22 @@ export function buildMonthGridDays(month: string): MonthGridDay[] {
 export type MenuDayStatus = 'none' | 'planned' | 'pending' | 'logged' | 'missed';
 
 /** Resolves a day cell's menu badge state from the calendar API's per-day menu flags. */
-export function menuDayStatus(hasMenu: boolean, logged: boolean, isPast: boolean, isToday: boolean): MenuDayStatus {
+export function menuDayStatus(hasMenu: boolean, logged: boolean, dayRelation: DayRelation): MenuDayStatus {
   if (!hasMenu) return 'none';
   if (logged) return 'logged';
-  if (isPast) return 'missed';
-  if (isToday) return 'pending';
+  if (dayRelation === 'past') return 'missed';
+  if (dayRelation === 'today') return 'pending';
   return 'planned';
+}
+
+/** Semantic color for a menu-day status — shared by the desktop corner badge and the bigger
+ * mobile status icon so the two can't drift on which color represents which state. `none` never
+ * renders, so it carries no tone. */
+export type MenuStatusTone = 'neutral' | 'accent' | 'success' | 'danger';
+
+export function menuStatusTone(status: Exclude<MenuDayStatus, 'none'>): MenuStatusTone {
+  if (status === 'logged') return 'success';
+  if (status === 'missed') return 'danger';
+  if (status === 'pending') return 'accent';
+  return 'neutral';
 }

--- a/packages/hub/src/app/calories/calories.utils.ts
+++ b/packages/hub/src/app/calories/calories.utils.ts
@@ -136,6 +136,15 @@ export function macroCalorieSplit(protein: number, carbs: number, fat: number): 
 }
 
 /**
+ * A value's share of a total as a rounded percentage, 0 when the total is 0 — the "what % of the
+ * day's macro calories is this one" math shared by the macro donut legend and the calendar day
+ * cell's per-macro lines.
+ */
+export function pctOfTotal(value: number, total: number): number {
+  return total > 0 ? Math.round((value / total) * 100) : 0;
+}
+
+/**
  * Groups an array of meal logs by their meal type.
  * @param meals - Array of meal log entries to group
  */


### PR DESCRIPTION
Taller mobile cells show per-macro percentages and a larger bottom-anchored
menu status icon instead of the cramped desktop corner badge. Today's
unlogged menu now renders a distinct "pending" state (amber clock) rather
than ever being able to show as "missed" (red X), since the day isn't over.

Also reuses the Weekly Menu tab's MealRow component for the calendar day
modal's planned-meal list, so log/edit/delete work there too instead of a
static read-only summary.