### PR TITLE
fix: return 409 instead of 500 when renaming a payee to a duplicate name

### DIFF
--- a/packages/hub/src/app/api/finances/payees/[id]/route.ts
+++ b/packages/hub/src/app/api/finances/payees/[id]/route.ts
@@ -49,11 +49,17 @@ export const PATCH = route({
   const budget = await getUserActiveBudget(user.id);
   if (!budget) routeHttpError(404, { error: 'No budget found' });
 
-  const payee = await updatePayee(user.id, budget.id, params.id, {
-    name: body.name,
-    aliases: body.aliases,
-    description: trimOrNull(body.description),
-  });
+  let payee;
+  try {
+    payee = await updatePayee(user.id, budget.id, params.id, {
+      name: body.name,
+      aliases: body.aliases,
+      description: trimOrNull(body.description),
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'Update failed';
+    routeHttpError(msg === 'Payee not found' ? 404 : 409, { error: msg });
+  }
 
   return {
     id: payee.id,

--- a/packages/shared/src/services/finances/payees.test.ts
+++ b/packages/shared/src/services/finances/payees.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { findPayeeByNameOrAlias, getPayees, mergePayees } from './payees';
+import { findPayeeByNameOrAlias, getPayees, mergePayees, updatePayee } from './payees';
 
 // ─── Mocks ────────────────────────────────────────────────────────────────────
 
@@ -148,6 +148,48 @@ describe('findPayeeByNameOrAlias', () => {
     const result = await findPayeeByNameOrAlias('user-1', 1, 'unknown vendor');
 
     expect(result).toBeNull();
+  });
+});
+
+// ─── updatePayee ─────────────────────────────────────────────────────────────
+
+describe('updatePayee', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(hasAccessToBudget).mockResolvedValue(true);
+  });
+
+  it('throws a clear error instead of a DB constraint violation when renaming to an existing payee name', async () => {
+    const collidingPayee = makeDbPayee(2, 'Kaufland');
+    (vi.mocked(db) as any).select.mockReturnValue({
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockResolvedValue([collidingPayee]),
+    });
+
+    await expect(updatePayee('user-1', 1, 1, { name: 'kaufland' })).rejects.toThrow(
+      'A payee named "kaufland" already exists',
+    );
+    expect((vi.mocked(db) as any).update).not.toHaveBeenCalled();
+  });
+
+  it('allows renaming a payee to its own current name', async () => {
+    const self = makeDbPayee(1, 'Kaufland');
+    (vi.mocked(db) as any).select.mockReturnValue({
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockResolvedValue([self]),
+    });
+    const updated = { ...self, name: 'Kaufland' };
+    (vi.mocked(db) as any).update.mockReturnValue({
+      set: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      returning: vi.fn().mockResolvedValue([updated]),
+    });
+
+    const result = await updatePayee('user-1', 1, 1, { name: 'Kaufland' });
+
+    expect(result).toEqual(updated);
   });
 });
 

--- a/packages/shared/src/services/finances/payees.ts
+++ b/packages/shared/src/services/finances/payees.ts
@@ -3,7 +3,7 @@
  * - findPayeeByNameOrAlias(userId, budgetId, name) — resolves a payee by canonical name or aliases
  * - upsertPayee(userId, budgetId, name) — insert-or-return, case-insensitive via normalizedName/aliases matching
  * - resolvePayeeIdByNameOrAlias(userId, budgetId, name) — resolves payee id or undefined
- * - updatePayee(userId, budgetId, payeeId, patch) — updates payee name/aliases/description
+ * - updatePayee(userId, budgetId, payeeId, patch) — updates payee name/aliases/description; throws a clear error (not a DB constraint violation) when the new name collides with another payee in the budget
  * - getPayees(userId, budgetId) — returns all payees ranked by user usage; includes aliases, description, and stats
  * - getPayeeSummary(userId, budgetId, payeeId) — all-time stats for a single payee: txCount, totalSpent, totalIncome, avgSpent, firstDate, lastDate, topCategory, topAccount
  * - deletePayee(userId, budgetId, payeeId) — hard delete
@@ -126,8 +126,19 @@ export async function updatePayee(
   if (patch.name !== undefined) {
     const trimmed = patch.name.trim();
     if (!trimmed) throw new Error('Payee name is required');
+    const normalizedName = normalizePayeeName(trimmed);
+
+    const [existing] = await db
+      .select({ id: financePayees.id })
+      .from(financePayees)
+      .where(and(eq(financePayees.budgetId, budgetId), eq(financePayees.normalizedName, normalizedName)))
+      .limit(1);
+    if (existing && existing.id !== payeeId) {
+      throw new Error(`A payee named "${trimmed}" already exists`);
+    }
+
     changes.name = trimmed;
-    changes.normalizedName = normalizePayeeName(trimmed);
+    changes.normalizedName = normalizedName;
   }
   if (patch.aliases !== undefined) {
     changes.aliases = patch.aliases.map(a => a.trim()).filter(Boolean);


### PR DESCRIPTION
financePayees has a unique index on (budgetId, normalizedName), but
updatePayee never checked for a collision before writing, so renaming a
payee to a name matching another payee (case-insensitively) threw a raw
Postgres constraint violation that the PATCH route left uncaught,
surfacing as a bare 500. updatePayee now pre-checks for the collision and
throws a clear error, and the route catches it and returns 409 (404 if
the payee itself is missing).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018TLbhFdHgPfohdbLriFpri